### PR TITLE
Add ridge pipeline to transformers

### DIFF
--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -36,10 +36,10 @@
       "\n",
       "Python dependencies:\n",
       "      sklearn: 1.7.dev0\n",
-      "          pip: 24.3.1\n",
-      "   setuptools: 75.6.0\n",
-      "        numpy: 2.0.2\n",
-      "        scipy: 1.14.1\n",
+      "          pip: 25.0\n",
+      "   setuptools: 75.8.0\n",
+      "        numpy: 2.1.3\n",
+      "        scipy: 1.15.1\n",
       "       Cython: 3.0.11\n",
       "       pandas: 2.2.3\n",
       "   matplotlib: 3.10.0\n",
@@ -49,6 +49,15 @@
       "Built with OpenMP: True\n",
       "\n",
       "threadpoolctl info:\n",
+      "       user_api: blas\n",
+      "   internal_api: openblas\n",
+      "    num_threads: 8\n",
+      "         prefix: libopenblas\n",
+      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libopenblas.0.dylib\n",
+      "        version: 0.3.28\n",
+      "threading_layer: openmp\n",
+      "   architecture: VORTEX\n",
+      "\n",
       "       user_api: openmp\n",
       "   internal_api: openmp\n",
       "    num_threads: 8\n",
@@ -123,7 +132,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 15.76it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 10.22it/s]\n"
      ]
     },
     {
@@ -139,14 +148,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 44.00it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 46.02it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostRegressor: (min_p_value: 0.135, mean_p_value=0.582)\n",
+      "✅ AdaBoostRegressor: (min_p_value: 0.071, mean_p_value=0.679)\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -157,14 +166,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 50.84it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 30.82it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingClassifier: (min_p_value: 0.000, mean_p_value=0.273)\n",
+      "❌ BaggingClassifier: (min_p_value: 0.000, mean_p_value=0.259)\n",
       "Evaluating BaggingRegressor()\n"
      ]
     },
@@ -172,14 +181,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 48.87it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 43.01it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingRegressor: (min_p_value: 0.000, mean_p_value=0.316)\n",
+      "❌ BaggingRegressor: (min_p_value: 0.000, mean_p_value=0.212)\n",
       "✅ BayesianRidge() passed the deterministic check\n",
       "✅ BernoulliNB() passed the deterministic check\n",
       "⚠ BernoulliRBM does not support sample_weight\n",
@@ -200,7 +209,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 697.71it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 788.17it/s]\n"
      ]
     },
     {
@@ -215,14 +224,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 367.90it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 842.20it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DecisionTreeRegressor: (min_p_value: 0.035, mean_p_value=0.689)\n",
+      "❌ DecisionTreeRegressor: (min_p_value: 0.035, mean_p_value=0.713)\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -232,7 +241,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1686.54it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1804.39it/s]\n"
      ]
     },
     {
@@ -248,7 +257,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 677.78it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 254.85it/s]\n"
      ]
     },
     {
@@ -263,7 +272,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 34.07it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 30.92it/s]\n"
      ]
     },
     {
@@ -278,7 +287,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 568.11it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 698.60it/s]\n"
      ]
     },
     {
@@ -293,14 +302,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 627.47it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 816.50it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreeRegressor: (min_p_value: 0.000, mean_p_value=0.699)\n",
+      "❌ ExtraTreeRegressor: (min_p_value: 0.035, mean_p_value=0.719)\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -308,7 +317,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 12.25it/s]\n"
+      "100%|██████████| 30/30 [00:03<00:00,  8.91it/s]\n"
      ]
     },
     {
@@ -323,14 +332,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 11.85it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 11.33it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreesRegressor: (min_p_value: 0.035, mean_p_value=0.583)\n",
+      "❌ ExtraTreesRegressor: (min_p_value: 0.003, mean_p_value=0.536)\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -351,14 +360,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:06<00:00,  4.96it/s]\n"
+      "100%|██████████| 30/30 [00:07<00:00,  4.05it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingClassifier: (min_p_value: 0.239, mean_p_value=0.800)\n",
+      "✅ GradientBoostingClassifier: (min_p_value: 0.135, mean_p_value=0.752)\n",
       "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -366,14 +375,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 21.05it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 23.81it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingRegressor: (min_p_value: 0.135, mean_p_value=0.826)\n",
+      "✅ GradientBoostingRegressor: (min_p_value: 0.239, mean_p_value=0.930)\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -383,14 +392,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 12.22it/s]\n"
+      "100%|██████████| 30/30 [00:03<00:00,  9.73it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ HistGradientBoostingClassifier: (min_p_value: 0.000, mean_p_value=0.027)\n",
+      "❌ HistGradientBoostingClassifier: (min_p_value: 0.000, mean_p_value=0.043)\n",
       "Evaluating HistGradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -398,14 +407,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 35.79it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 30.85it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ HistGradientBoostingRegressor: (min_p_value: 0.000, mean_p_value=0.090)\n",
+      "❌ HistGradientBoostingRegressor: (min_p_value: 0.000, mean_p_value=0.009)\n",
       "❌ HuberRegressor() failed the deterministic check\n",
       "⚠ IncrementalPCA does not support sample_weight\n",
       "⚠ Isomap does not support sample_weight\n",
@@ -433,7 +442,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 648.65it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 929.12it/s]\n"
      ]
     },
     {
@@ -448,7 +457,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 43.50it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 42.37it/s]\n"
      ]
     },
     {
@@ -469,14 +478,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 89.64it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 48.70it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LinearSVC: (min_p_value: 0.000, mean_p_value=0.044)\n",
+      "❌ LinearSVC: (min_p_value: 0.000, mean_p_value=0.015)\n",
       "Evaluating LinearSVR(dual=True)\n"
      ]
     },
@@ -484,14 +493,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1126.04it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 260.26it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LinearSVR: (min_p_value: 0.000, mean_p_value=0.194)\n",
+      "❌ LinearSVR: (min_p_value: 0.000, mean_p_value=0.051)\n",
       "⚠ LocallyLinearEmbedding does not support sample_weight\n",
       "Evaluating LogisticRegression(dual=True, max_iter=10000, solver='liblinear')\n"
      ]
@@ -500,14 +509,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 156.06it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 165.09it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LogisticRegression: (min_p_value: 0.000, mean_p_value=0.103)\n",
+      "❌ LogisticRegression: (min_p_value: 0.000, mean_p_value=0.144)\n",
       "Skipping LogisticRegressionCV\n",
       "Evaluating MLPClassifier()\n"
      ]
@@ -516,7 +525,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 13.13it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 10.65it/s]\n"
      ]
     },
     {
@@ -531,7 +540,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 14.35it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 13.12it/s]\n"
      ]
     },
     {
@@ -566,14 +575,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 239.42it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 251.54it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ NuSVC: (min_p_value: 0.000, mean_p_value=0.006)\n",
+      "❌ NuSVC: (min_p_value: 0.000, mean_p_value=0.029)\n",
       "❌ NuSVR() failed the deterministic check\n",
       "⚠ Nystroem does not support sample_weight\n",
       "⚠ OPTICS does not support sample_weight\n",
@@ -598,14 +607,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 402.54it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 398.95it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ Perceptron: (min_p_value: 0.000, mean_p_value=0.006)\n",
+      "❌ Perceptron: (min_p_value: 0.000, mean_p_value=0.010)\n",
       "✅ PoissonRegressor() passed the deterministic check\n",
       "⚠ PolynomialCountSketch does not support sample_weight\n",
       "⚠ PolynomialFeatures does not support sample_weight\n",
@@ -620,7 +629,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  3%|▎         | 1/30 [00:00<00:01, 18.93it/s]\n"
+      " 40%|████      | 12/30 [00:00<00:00, 25.97it/s]\n"
      ]
     },
     {
@@ -641,14 +650,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:03<00:00,  8.77it/s]\n"
+      "100%|██████████| 30/30 [00:03<00:00,  7.57it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomForestClassifier: (min_p_value: 0.000, mean_p_value=0.355)\n",
+      "❌ RandomForestClassifier: (min_p_value: 0.000, mean_p_value=0.213)\n",
       "Evaluating RandomForestRegressor(max_features=0.5)\n"
      ]
     },
@@ -656,14 +665,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 10.03it/s]\n"
+      "100%|██████████| 30/30 [00:03<00:00,  8.52it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomForestRegressor: (min_p_value: 0.000, mean_p_value=0.093)\n",
+      "❌ RandomForestRegressor: (min_p_value: 0.000, mean_p_value=0.139)\n",
       "Evaluating RandomTreesEmbedding(n_estimators=10)\n"
      ]
     },
@@ -671,17 +680,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/30 [00:00<?, ?it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 72.42it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomTreesEmbedding(n_estimators=10) error with: X has 174 features, but GaussianRandomProjection is expecting 169 features as input.\n",
+      "✅ RandomTreesEmbedding: (min_p_value: 0.135, mean_p_value=0.631)\n",
       "⚠ RegressorChain does not support sample_weight\n",
-      "Evaluating Ridge(solver='sag')\n",
-      "❌ Ridge(solver='sag') error with: Floating-point under-/overflow occurred at epoch #969. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Evaluating Ridge(solver='sag')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 144.18it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ Ridge: (min_p_value: 0.000, mean_p_value=0.000)\n",
       "✅ RidgeCV() passed the deterministic check\n",
       "Evaluating RidgeClassifier(solver='saga')\n"
      ]
@@ -690,14 +712,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  3%|▎         | 1/30 [00:00<00:01, 15.13it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 44.67it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RidgeClassifier(solver='saga') error with: Floating-point under-/overflow occurred at epoch #997. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ RidgeClassifier: (min_p_value: 0.000, mean_p_value=0.000)\n",
       "✅ RidgeClassifierCV() passed the deterministic check\n",
       "⚠ RobustScaler does not support sample_weight\n",
       "Evaluating SGDClassifier()\n"
@@ -707,14 +729,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 402.91it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 307.60it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ SGDClassifier: (min_p_value: 0.000, mean_p_value=0.001)\n",
+      "❌ SGDClassifier: (min_p_value: 0.000, mean_p_value=0.000)\n",
       "Evaluating SGDRegressor()\n"
      ]
     },
@@ -722,7 +744,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 675.01it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 696.67it/s]\n"
      ]
     },
     {
@@ -737,7 +759,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 373.15it/s]"
+      "100%|██████████| 30/30 [00:00<00:00, 298.07it/s]"
      ]
     },
     {
@@ -823,7 +845,7 @@
     "        continue\n",
     "\n",
     "    # XXX: how to handle stochastic clustering estimators?\n",
-    "    if is_clusterer(est):\n",
+    "    if is_clusterer(est) and not hasattr(est, \"transform\"):\n",
     "        print(f\"⚠ {est_name} skipped: missing proper handling of clustering estimators\")\n",
     "        continue\n",
     "\n",
@@ -871,9 +893,9 @@
      "text": [
       "✅ 19 passed the deterministic test\n",
       "❌ 4 failed the deterministic test\n",
-      "✅ 14 passed the statistical test\n",
-      "❌ 17 failed the statistical test\n",
-      "❌ 5 other errors\n",
+      "✅ 15 passed the statistical test\n",
+      "❌ 19 failed the statistical test\n",
+      "❌ 2 other errors\n",
       "⚠ 112 estimators lack sample_weight support\n"
      ]
     }
@@ -943,190 +965,208 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>HistGradientBoostingClassifier</td>\n",
+       "      <th>16</th>\n",
+       "      <td>HistGradientBoostingRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.027325</td>\n",
+       "      <td>8.635796e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28</th>\n",
+       "      <th>31</th>\n",
        "      <td>SGDClassifier</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.000586</td>\n",
+       "      <td>1.087025e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
+       "      <th>25</th>\n",
+       "      <td>Perceptron</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.093150</td>\n",
+       "      <td>9.608038e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>24</th>\n",
        "      <td>NuSVC</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.005659</td>\n",
+       "      <td>2.930086e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>21</th>\n",
        "      <td>LogisticRegression</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.102564</td>\n",
+       "      <td>1.441737e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
        "      <td>LinearSVC</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.043760</td>\n",
+       "      <td>1.455970e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>29</th>\n",
+       "      <th>32</th>\n",
        "      <td>SGDRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.000001</td>\n",
+       "      <td>7.891067e-07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>30</th>\n",
+       "      <th>15</th>\n",
+       "      <td>HistGradientBoostingClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>4.349046e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
        "      <td>SVC</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>0.001153</td>\n",
+       "      <td>1.182655e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>Perceptron</td>\n",
+       "      <th>27</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
        "      <td>1.014674e-15</td>\n",
-       "      <td>0.006190</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>HistGradientBoostingRegressor</td>\n",
-       "      <td>5.787024e-13</td>\n",
-       "      <td>0.089766</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>RandomForestClassifier</td>\n",
-       "      <td>8.246510e-12</td>\n",
-       "      <td>0.354587</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaggingClassifier</td>\n",
-       "      <td>8.466416e-10</td>\n",
-       "      <td>0.273324</td>\n",
+       "      <td>1.387822e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>BaggingRegressor</td>\n",
+       "      <td>8.246510e-12</td>\n",
+       "      <td>2.121099e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>RandomForestClassifier</td>\n",
        "      <td>8.466416e-10</td>\n",
-       "      <td>0.315516</td>\n",
+       "      <td>2.132368e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingClassifier</td>\n",
+       "      <td>6.531236e-09</td>\n",
+       "      <td>2.587033e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>RidgeClassifier</td>\n",
+       "      <td>4.326944e-08</td>\n",
+       "      <td>1.466088e-04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>Ridge</td>\n",
+       "      <td>1.275006e-06</td>\n",
+       "      <td>3.041802e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>20</th>\n",
        "      <td>LinearSVR</td>\n",
        "      <td>5.795482e-06</td>\n",
-       "      <td>0.193954</td>\n",
+       "      <td>5.087924e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
+       "      <td>2.530062e-03</td>\n",
+       "      <td>5.363065e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>2.933405e-04</td>\n",
-       "      <td>0.698977</td>\n",
+       "      <td>3.458008e-02</td>\n",
+       "      <td>7.185169e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>DecisionTreeRegressor</td>\n",
        "      <td>3.458008e-02</td>\n",
-       "      <td>0.689325</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>3.458008e-02</td>\n",
-       "      <td>0.583044</td>\n",
+       "      <td>7.126373e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>AdaBoostRegressor</td>\n",
-       "      <td>1.350035e-01</td>\n",
-       "      <td>0.582181</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>1.350035e-01</td>\n",
-       "      <td>0.825844</td>\n",
+       "      <td>7.088799e-02</td>\n",
+       "      <td>6.792121e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
        "      <td>GradientBoostingClassifier</td>\n",
+       "      <td>1.350035e-01</td>\n",
+       "      <td>7.524487e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>RandomTreesEmbedding</td>\n",
+       "      <td>1.350035e-01</td>\n",
+       "      <td>6.310016e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
        "      <td>2.390730e-01</td>\n",
-       "      <td>0.799679</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>AdaBoostClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>MLPClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>MLPRegressor</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>LassoCV</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>Lasso</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>DummyClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>ExtraTreesClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>9.301572e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>ExtraTreeClassifier</td>\n",
        "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.000000e+00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>ElasticNet</td>\n",
+       "      <th>4</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
        "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>ElasticNetCV</td>\n",
        "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>LassoCV</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>Lasso</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>DummyClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>ExtraTreesClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AdaBoostClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1134,37 +1174,40 @@
       ],
       "text/plain": [
        "                    estimator_name   min_p_value  mean_p_value\n",
-       "15  HistGradientBoostingClassifier  1.691123e-17      0.027325\n",
-       "28                   SGDClassifier  1.691123e-17      0.000586\n",
-       "27           RandomForestRegressor  1.691123e-17      0.093150\n",
-       "24                           NuSVC  1.691123e-17      0.005659\n",
-       "21              LogisticRegression  1.691123e-17      0.102564\n",
-       "19                       LinearSVC  1.691123e-17      0.043760\n",
-       "29                    SGDRegressor  1.691123e-17      0.000001\n",
-       "30                             SVC  1.691123e-17      0.001153\n",
-       "25                      Perceptron  1.014674e-15      0.006190\n",
-       "16   HistGradientBoostingRegressor  5.787024e-13      0.089766\n",
-       "26          RandomForestClassifier  8.246510e-12      0.354587\n",
-       "2                BaggingClassifier  8.466416e-10      0.273324\n",
-       "3                 BaggingRegressor  8.466416e-10      0.315516\n",
-       "20                       LinearSVR  5.795482e-06      0.193954\n",
-       "10              ExtraTreeRegressor  2.933405e-04      0.698977\n",
-       "5            DecisionTreeRegressor  3.458008e-02      0.689325\n",
-       "12             ExtraTreesRegressor  3.458008e-02      0.583044\n",
-       "1                AdaBoostRegressor  1.350035e-01      0.582181\n",
-       "14       GradientBoostingRegressor  1.350035e-01      0.825844\n",
-       "13      GradientBoostingClassifier  2.390730e-01      0.799679\n",
-       "0               AdaBoostClassifier  1.000000e+00      1.000000\n",
-       "4           DecisionTreeClassifier  1.000000e+00      1.000000\n",
-       "22                   MLPClassifier  1.000000e+00      1.000000\n",
-       "23                    MLPRegressor  1.000000e+00      1.000000\n",
-       "18                         LassoCV  1.000000e+00      1.000000\n",
-       "17                           Lasso  1.000000e+00      1.000000\n",
-       "6                  DummyClassifier  1.000000e+00      1.000000\n",
-       "11            ExtraTreesClassifier  1.000000e+00      1.000000\n",
-       "9              ExtraTreeClassifier  1.000000e+00      1.000000\n",
-       "7                       ElasticNet  1.000000e+00      1.000000\n",
-       "8                     ElasticNetCV  1.000000e+00      1.000000"
+       "16   HistGradientBoostingRegressor  1.691123e-17  8.635796e-03\n",
+       "31                   SGDClassifier  1.691123e-17  1.087025e-04\n",
+       "25                      Perceptron  1.691123e-17  9.608038e-03\n",
+       "24                           NuSVC  1.691123e-17  2.930086e-02\n",
+       "21              LogisticRegression  1.691123e-17  1.441737e-01\n",
+       "19                       LinearSVC  1.691123e-17  1.455970e-02\n",
+       "32                    SGDRegressor  1.691123e-17  7.891067e-07\n",
+       "15  HistGradientBoostingClassifier  1.691123e-17  4.349046e-02\n",
+       "33                             SVC  1.691123e-17  1.182655e-03\n",
+       "27           RandomForestRegressor  1.014674e-15  1.387822e-01\n",
+       "3                 BaggingRegressor  8.246510e-12  2.121099e-01\n",
+       "26          RandomForestClassifier  8.466416e-10  2.132368e-01\n",
+       "2                BaggingClassifier  6.531236e-09  2.587033e-01\n",
+       "30                 RidgeClassifier  4.326944e-08  1.466088e-04\n",
+       "29                           Ridge  1.275006e-06  3.041802e-04\n",
+       "20                       LinearSVR  5.795482e-06  5.087924e-02\n",
+       "12             ExtraTreesRegressor  2.530062e-03  5.363065e-01\n",
+       "10              ExtraTreeRegressor  3.458008e-02  7.185169e-01\n",
+       "5            DecisionTreeRegressor  3.458008e-02  7.126373e-01\n",
+       "1                AdaBoostRegressor  7.088799e-02  6.792121e-01\n",
+       "13      GradientBoostingClassifier  1.350035e-01  7.524487e-01\n",
+       "28            RandomTreesEmbedding  1.350035e-01  6.310016e-01\n",
+       "14       GradientBoostingRegressor  2.390730e-01  9.301572e-01\n",
+       "9              ExtraTreeClassifier  1.000000e+00  1.000000e+00\n",
+       "4           DecisionTreeClassifier  1.000000e+00  1.000000e+00\n",
+       "22                   MLPClassifier  1.000000e+00  1.000000e+00\n",
+       "8                     ElasticNetCV  1.000000e+00  1.000000e+00\n",
+       "18                         LassoCV  1.000000e+00  1.000000e+00\n",
+       "17                           Lasso  1.000000e+00  1.000000e+00\n",
+       "6                  DummyClassifier  1.000000e+00  1.000000e+00\n",
+       "7                       ElasticNet  1.000000e+00  1.000000e+00\n",
+       "11            ExtraTreesClassifier  1.000000e+00  1.000000e+00\n",
+       "23                    MLPRegressor  1.000000e+00  1.000000e+00\n",
+       "0               AdaBoostClassifier  1.000000e+00  1.000000e+00"
       ]
      },
      "execution_count": 7,
@@ -1196,62 +1239,62 @@
       "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
       "Comparing the output of HuberRegressor.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
       "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00028263\n",
-      "Max relative difference among violations: 2.27543844\n",
-      " ACTUAL: array([-4.869395e-06,  9.999880e-01,  1.999986e+00,  1.202203e+00,\n",
-      "        2.430233e+00,  1.000004e+00,  2.000005e+00,  1.999990e+00,\n",
-      "        1.656825e+00,  2.000005e+00,  1.576781e+00,  1.294958e+00,\n",
-      "        1.829464e+00,  1.000007e+00,  9.999624e-01])\n",
-      " DESIRED: array([-1.486639e-06,  9.999957e-01,  1.999999e+00,  1.202240e+00,\n",
-      "        2.430310e+00,  9.999945e-01,  1.999996e+00,  1.999997e+00,\n",
-      "        1.656966e+00,  1.999998e+00,  1.576821e+00,  1.295021e+00,\n",
-      "        1.829527e+00,  1.000007e+00,  1.000245e+00])\n",
+      "Max absolute difference among violations: 0.00051052\n",
+      "Max relative difference among violations: 7.5912896\n",
+      " ACTUAL: array([-2.323244e-05,  9.999910e-01,  2.000039e+00,  1.202210e+00,\n",
+      "        2.430282e+00,  9.999892e-01,  1.999998e+00,  2.000024e+00,\n",
+      "        1.656899e+00,  1.999991e+00,  1.576810e+00,  1.295011e+00,\n",
+      "        1.829514e+00,  1.000022e+00,  1.000070e+00])\n",
+      " DESIRED: array([-2.704185e-06,  9.999971e-01,  2.000005e+00,  1.202141e+00,\n",
+      "        2.430112e+00,  9.999871e-01,  1.999991e+00,  2.000007e+00,\n",
+      "        1.656642e+00,  1.999968e+00,  1.576735e+00,  1.294886e+00,\n",
+      "        1.829381e+00,  1.000010e+00,  9.995597e-01])\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 27, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
       "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1575, in check_sample_weight_equivalence_on_dense_data\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
       "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
       "    return fn(*args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1571, in _check_sample_weight_equivalence\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
       "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
       "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
       "    np_assert_allclose(\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1684, in assert_allclose\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
       "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
       "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
       "    return func(*args, **kwds)\n",
       "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 885, in assert_array_compare\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
       "    raise AssertionError(msg)\n",
       "AssertionError: \n",
       "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
       "Comparing the output of HuberRegressor.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
       "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00028263\n",
-      "Max relative difference among violations: 2.27543844\n",
-      " ACTUAL: array([-4.869395e-06,  9.999880e-01,  1.999986e+00,  1.202203e+00,\n",
-      "        2.430233e+00,  1.000004e+00,  2.000005e+00,  1.999990e+00,\n",
-      "        1.656825e+00,  2.000005e+00,  1.576781e+00,  1.294958e+00,\n",
-      "        1.829464e+00,  1.000007e+00,  9.999624e-01])\n",
-      " DESIRED: array([-1.486639e-06,  9.999957e-01,  1.999999e+00,  1.202240e+00,\n",
-      "        2.430310e+00,  9.999945e-01,  1.999996e+00,  1.999997e+00,\n",
-      "        1.656966e+00,  1.999998e+00,  1.576821e+00,  1.295021e+00,\n",
-      "        1.829527e+00,  1.000007e+00,  1.000245e+00])\n",
+      "Max absolute difference among violations: 0.00051052\n",
+      "Max relative difference among violations: 7.5912896\n",
+      " ACTUAL: array([-2.323244e-05,  9.999910e-01,  2.000039e+00,  1.202210e+00,\n",
+      "        2.430282e+00,  9.999892e-01,  1.999998e+00,  2.000024e+00,\n",
+      "        1.656899e+00,  1.999991e+00,  1.576810e+00,  1.295011e+00,\n",
+      "        1.829514e+00,  1.000022e+00,  1.000070e+00])\n",
+      " DESIRED: array([-2.704185e-06,  9.999971e-01,  2.000005e+00,  1.202141e+00,\n",
+      "        2.430112e+00,  9.999871e-01,  1.999991e+00,  2.000007e+00,\n",
+      "        1.656642e+00,  1.999968e+00,  1.576735e+00,  1.294886e+00,\n",
+      "        1.829381e+00,  1.000010e+00,  9.995597e-01])\n",
       "\n",
       "❌ IsotonicRegression(): Isotonic regression input X should be a 1d array or 2d array with 1 feature\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 27, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
       "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1575, in check_sample_weight_equivalence_on_dense_data\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
       "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
       "    return fn(*args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1559, in _check_sample_weight_equivalence\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1560, in _check_sample_weight_equivalence\n",
       "    estimator_repeated.fit(X_repeated, y=y_repeated, sample_weight=None)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
@@ -1280,25 +1323,25 @@
       "       1.233376e+00, 1.999820e+00, 1.401014e+00, 1.398252e+00,\n",
       "       1.432028e+00, 1.000286e+00, 1.000143e+00])\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 27, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
       "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1575, in check_sample_weight_equivalence_on_dense_data\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
       "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
       "    return fn(*args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1571, in _check_sample_weight_equivalence\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
       "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
       "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
       "    np_assert_allclose(\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1684, in assert_allclose\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
       "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
       "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
       "    return func(*args, **kwds)\n",
       "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 885, in assert_array_compare\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
       "    raise AssertionError(msg)\n",
       "AssertionError: \n",
       "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
@@ -1328,25 +1371,25 @@
       "       1.900122, 1.900199, 1.253611, 1.900075, 1.415291, 1.402263,\n",
       "       1.441794, 1.099432, 1.0997  ])\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 27, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
       "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1575, in check_sample_weight_equivalence_on_dense_data\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
       "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
       "    return fn(*args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1571, in _check_sample_weight_equivalence\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
       "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
       "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
       "    np_assert_allclose(\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1684, in assert_allclose\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
       "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
       "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
       "    return func(*args, **kwds)\n",
       "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 885, in assert_array_compare\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
       "    raise AssertionError(msg)\n",
       "AssertionError: \n",
       "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
@@ -1394,14 +1437,39 @@
      "text": [
       "❌ KBinsDiscretizer(encode='ordinal', subsample=50): sample_weight.shape == (100,), expected (50,)!\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 42, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 44, in <module>\n",
       "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
       "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 82, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 83, in check_weighted_repeated_estimator_fit_equivalence\n",
       "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
       "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 240, in multifit_over_weighted_and_repeated\n",
-      "    est_ref.fit(X_train, y_train, sample_weight=sample_weight_train)\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 260, in multifit_over_weighted_and_repeated\n",
+      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 190, in check_pipeline_and_fit\n",
+      "    est = est.fit(\n",
+      "          ^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/pipeline.py\", line 654, in fit\n",
+      "    Xt = self._fit(X, y, routed_params, raw_params=params)\n",
+      "         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/pipeline.py\", line 588, in _fit\n",
+      "    X, fitted_transformer = fit_transform_one_cached(\n",
+      "                            ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/joblib/memory.py\", line 312, in __call__\n",
+      "    return self.func(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/pipeline.py\", line 1551, in _fit_transform_one\n",
+      "    res = transformer.fit_transform(X, y, **params.get(\"fit_transform\", {}))\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_set_output.py\", line 319, in wrapped\n",
+      "    data_to_wrap = f(self, X, *args, **kwargs)\n",
+      "                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 921, in fit_transform\n",
+      "    return self.fit(X, y, **fit_params).transform(X)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
@@ -1414,14 +1482,18 @@
       "\n",
       "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 42, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 44, in <module>\n",
       "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
       "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 82, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 83, in check_weighted_repeated_estimator_fit_equivalence\n",
       "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
       "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 279, in multifit_over_weighted_and_repeated\n",
-      "    est_weighted.fit(X_train, y_train, sample_weight=sample_weight_train)\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 299, in multifit_over_weighted_and_repeated\n",
+      "    est_weighted = check_pipeline_and_fit(\n",
+      "                   ^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 197, in check_pipeline_and_fit\n",
+      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
@@ -1439,90 +1511,12 @@
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
       "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
       "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 717, in _average\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 730, in _average\n",
       "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
       "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 570, in average\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 575, in average\n",
       "    raise ZeroDivisionError(\n",
       "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n",
-      "❌ RandomTreesEmbedding(n_estimators=10): X has 174 features, but GaussianRandomProjection is expecting 169 features as input.\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 42, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 82, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
-      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 286, in multifit_over_weighted_and_repeated\n",
-      "    predictions_repeated_all.append(project(predictions_repeated))\n",
-      "                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_set_output.py\", line 319, in wrapped\n",
-      "    data_to_wrap = f(self, X, *args, **kwargs)\n",
-      "                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/random_projection.py\", line 604, in transform\n",
-      "    X = validate_data(\n",
-      "        ^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 2963, in validate_data\n",
-      "    _check_n_features(_estimator, X, reset=reset)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 2827, in _check_n_features\n",
-      "    raise ValueError(\n",
-      "ValueError: X has 174 features, but GaussianRandomProjection is expecting 169 features as input.\n",
-      "\n",
-      "❌ Ridge(solver='sag'): Floating-point under-/overflow occurred at epoch #969. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 42, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 82, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
-      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 240, in multifit_over_weighted_and_repeated\n",
-      "    est_ref.fit(X_train, y_train, sample_weight=sample_weight_train)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1249, in fit\n",
-      "    return super().fit(X, y, sample_weight=sample_weight)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
-      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
-      "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
-      "    coef_, n_iter_, _ = sag_solver(\n",
-      "                        ^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
-      "    num_seen, n_iter_ = sag(\n",
-      "                        ^^^^\n",
-      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #969. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
-      "\n",
-      "❌ RidgeClassifier(solver='saga'): Floating-point under-/overflow occurred at epoch #997. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_19224/2102651931.py\", line 42, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 82, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
-      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 279, in multifit_over_weighted_and_repeated\n",
-      "    est_weighted.fit(X_train, y_train, sample_weight=sample_weight_train)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1571, in fit\n",
-      "    super().fit(X, Y, sample_weight=sample_weight)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
-      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
-      "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
-      "    coef_, n_iter_, _ = sag_solver(\n",
-      "                        ^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
-      "    num_seen, n_iter_ = sag(\n",
-      "                        ^^^^\n",
-      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #997. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "\n"
      ]
     }

--- a/src/sample_weight_audit/data.py
+++ b/src/sample_weight_audit/data.py
@@ -1,7 +1,6 @@
 import numpy as np
-from scipy.sparse import csr_matrix, csr_array
-from sklearn.datasets import make_classification, make_regression, make_blobs
-from sklearn.base import is_regressor, is_classifier
+from sklearn.datasets import make_classification, make_regression
+from sklearn.base import is_classifier
 from sklearn.utils import check_random_state, shuffle
 from sklearn.model_selection import train_test_split
 
@@ -83,7 +82,7 @@ def make_data_for_estimator(
     total_weight_sum = np.sum(sample_weight_sw) + np.sum(sample_weight_lw)
     assert np.sum(sample_weight_sw) < 0.3 * total_weight_sum
 
-    if is_regressor(est):
+    if not is_classifier(est):
         X_sw, y_sw = make_regression(
             n_samples=n_samples_sw,
             n_features=n_features_sw,
@@ -95,7 +94,6 @@ def make_data_for_estimator(
             random_state=rng,  # rng is different because mutated
         )
     else:
-        # Bloby data, both to test for classifiers and transformers.
         X_sw, y_sw = make_classification(
             n_samples=n_samples_sw,
             n_features=n_features_sw,

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -180,10 +180,15 @@ def compute_predictions(est, X):
         raise NotImplementedError(f"Estimator type not supported: {est}")
 
 
-def check_pipeline_and_fit(est, X, y, sample_weight=None):
+def check_pipeline_and_fit(est, X, y, sample_weight=None, seed=None):
 
     if hasattr(est, "transform"):
-        est = Pipeline([("transformer", est), ("ridge", Ridge())])
+        est = Pipeline(
+            [
+                ("transformer", est),
+                ("ridge", Ridge(random_state=seed, fit_intercept=False)),
+            ]
+        )
         est = est.fit(
             X,
             y,
@@ -294,10 +299,17 @@ def multifit_over_weighted_and_repeated(
         est_weighted = clone(est).set_params(random_state=seed, **extra_params_weighted)
         est_repeated = clone(est).set_params(random_state=seed, **extra_params_repeated)
         est_weighted = check_pipeline_and_fit(
-            est_weighted, X_train, y_train, sample_weight=sample_weight_train
+            est_weighted,
+            X_train,
+            y_train,
+            sample_weight=sample_weight_train,
+            seed=seed,
         )
         est_repeated = check_pipeline_and_fit(
-            est_repeated, X_resampled_by_weights, y_resampled_by_weights
+            est_repeated,
+            X_resampled_by_weights,
+            y_resampled_by_weights,
+            seed=seed,
         )
 
         predictions_weighted = compute_predictions(est_weighted, X_test_diverse_subset)

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -184,7 +184,12 @@ def check_pipeline_and_fit(est, X, y, sample_weight=None):
 
     if hasattr(est, "transform"):
         est = Pipeline([("transformer", est), ("ridge", Ridge())])
-        est = est.fit(X, y, transformer__sample_weight=sample_weight)
+        est = est.fit(
+            X,
+            y,
+            transformer__sample_weight=sample_weight,
+            ridge__sample_weight=sample_weight,
+        )
     else:
         est = est.fit(X, y, sample_weight=sample_weight)
     return est

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -172,8 +172,6 @@ def compute_predictions(est, X):
             return est.predict_proba(X)
         else:
             return est.decision_function(X)
-    elif isinstance(est, Pipeline):
-        return est.predict(X)
     elif hasattr(est, "transform"):
         return est.transform(X)
     else:
@@ -181,8 +179,7 @@ def compute_predictions(est, X):
 
 
 def check_pipeline_and_fit(est, X, y, sample_weight=None, seed=None):
-
-    if hasattr(est, "transform"):
+    if not is_classifier(est) and not is_regressor(est) and hasattr(est, "transform"):
         est = Pipeline(
             [
                 ("transformer", est),


### PR DESCRIPTION
Linked to issue #9, we now add a pipeline such that transformers take in regression data and pipeline through to Ridge regression allowing simplification of the problem.

TO DO:

- [x] Test on NoisyTransformer is failing with p-value less need to check for bugs