### PR TITLE
Fix pvalue behaviour

### DIFF
--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -135,18 +135,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 20.06it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 19.91it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ AdaBoostClassifier: (p_value: 0.000\n",
+      "✅ AdaBoostClassifier: (p_value: 1.000\n",
       "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
-      "                                                  max_features=0.5))\n",
-      "❌ AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
-      "                                                  max_features=0.5)) error with: index 97 is out of bounds for axis 0 with size 94\n",
+      "                                                  max_features=0.5))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 88.80it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ AdaBoostRegressor: (p_value: 0.135\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -157,7 +169,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 62.45it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 73.29it/s]\n"
      ]
     },
     {
@@ -172,7 +184,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 72.85it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 74.85it/s]\n"
      ]
     },
     {
@@ -185,8 +197,21 @@
       "⚠ BernoulliRBM does not support sample_weight\n",
       "⚠ Binarizer does not support sample_weight\n",
       "⚠ Birch does not support sample_weight\n",
-      "Evaluating BisectingKMeans(n_clusters=10)\n",
-      "❌ BisectingKMeans(n_clusters=10) error with: index 90 is out of bounds for axis 0 with size 90\n",
+      "Evaluating BisectingKMeans(n_clusters=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 403.63it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ BisectingKMeans: (p_value: 0.007\n",
       "⚠ CCA does not support sample_weight\n",
       "✅ CalibratedClassifierCV() passed the deterministic check\n",
       "✅ CategoricalNB() passed the deterministic check\n",
@@ -201,14 +226,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1012.83it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1114.62it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DecisionTreeClassifier: (p_value: 0.000\n",
+      "✅ DecisionTreeClassifier: (p_value: 1.000\n",
       "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
      ]
     },
@@ -216,7 +241,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1098.94it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1113.71it/s]\n"
      ]
     },
     {
@@ -233,14 +258,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 2160.64it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 2173.44it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DummyClassifier: (p_value: 0.035\n",
+      "✅ DummyClassifier: (p_value: 1.000\n",
       "✅ DummyRegressor() passed the deterministic check\n",
       "Evaluating ElasticNet(selection='random')\n"
      ]
@@ -249,14 +274,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1060.00it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1121.12it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ElasticNet: (p_value: 0.000\n",
+      "✅ ElasticNet: (p_value: 1.000\n",
       "Evaluating ElasticNetCV(selection='random')\n"
      ]
     },
@@ -264,16 +289,29 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 54.83it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 57.60it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ElasticNetCV: (p_value: 0.000\n",
-      "Evaluating ExtraTreeClassifier()\n",
-      "❌ ExtraTreeClassifier() error with: index 95 is out of bounds for axis 0 with size 92\n",
+      "✅ ElasticNetCV: (p_value: 1.000\n",
+      "Evaluating ExtraTreeClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 1146.80it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ExtraTreeClassifier: (p_value: 1.000\n",
       "Evaluating ExtraTreeRegressor()\n"
      ]
     },
@@ -281,14 +319,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1209.52it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1172.46it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreeRegressor: (p_value: 0.000\n",
+      "❌ ExtraTreeRegressor: (p_value: 0.016\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -296,14 +334,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 15.59it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 15.09it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreesClassifier: (p_value: 0.000\n",
+      "✅ ExtraTreesClassifier: (p_value: 1.000\n",
       "Evaluating ExtraTreesRegressor()\n"
      ]
     },
@@ -311,14 +349,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 16.38it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 16.27it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreesRegressor: (p_value: 0.000\n",
+      "❌ ExtraTreesRegressor: (p_value: 0.016\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -339,14 +377,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:04<00:00,  6.45it/s]\n"
+      "100%|██████████| 30/30 [00:05<00:00,  5.85it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ GradientBoostingClassifier: (p_value: 0.000\n",
+      "✅ GradientBoostingClassifier: (p_value: 0.393\n",
       "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -354,14 +392,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 31.83it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 31.90it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ GradientBoostingRegressor: (p_value: 0.000\n",
+      "✅ GradientBoostingRegressor: (p_value: 0.239\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -371,7 +409,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 17.57it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 18.53it/s]\n"
      ]
     },
     {
@@ -386,7 +424,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 52.53it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 55.40it/s]\n"
      ]
     },
     {
@@ -406,14 +444,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 422.14it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 429.58it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ KBinsDiscretizer: (p_value: 0.000\n",
+      "❌ KBinsDiscretizer: (p_value: 0.016\n",
       "Evaluating KMeans(n_clusters=10)\n"
      ]
     },
@@ -421,14 +459,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 578.99it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 569.43it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ KMeans: (p_value: 0.000\n",
+      "❌ KMeans: (p_value: 0.035\n",
       "⚠ KNNImputer does not support sample_weight\n",
       "⚠ KNeighborsClassifier does not support sample_weight\n",
       "⚠ KNeighborsRegressor does not support sample_weight\n",
@@ -442,8 +480,21 @@
       "⚠ LabelSpreading does not support sample_weight\n",
       "⚠ Lars does not support sample_weight\n",
       "⚠ LarsCV does not support sample_weight\n",
-      "Evaluating Lasso(selection='random')\n",
-      "❌ Lasso(selection='random') error with: index 98 is out of bounds for axis 0 with size 98\n",
+      "Evaluating Lasso(selection='random')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 1067.04it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Lasso: (p_value: 1.000\n",
       "Evaluating LassoCV(selection='random')\n"
      ]
     },
@@ -451,7 +502,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 55.60it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 57.27it/s]\n"
      ]
     },
     {
@@ -472,7 +523,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 95.71it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 80.53it/s]\n"
      ]
     },
     {
@@ -487,14 +538,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1417.89it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1475.15it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LinearSVR: (p_value: 0.000\n",
+      "❌ LinearSVR: (p_value: 0.003\n",
       "⚠ LocallyLinearEmbedding does not support sample_weight\n",
       "Evaluating LogisticRegression(dual=True, max_iter=10000, solver='liblinear')\n"
      ]
@@ -503,7 +554,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 287.14it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 316.50it/s]\n"
      ]
     },
     {
@@ -519,14 +570,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 14.95it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 17.10it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ MLPClassifier: (p_value: 0.000\n",
+      "✅ MLPClassifier: (p_value: 1.000\n",
       "Evaluating MLPRegressor()\n"
      ]
     },
@@ -534,14 +585,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 16.31it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 20.85it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ MLPRegressor: (p_value: 0.000\n",
+      "✅ MLPRegressor: (p_value: 1.000\n",
       "⚠ MaxAbsScaler does not support sample_weight\n",
       "⚠ MeanShift does not support sample_weight\n",
       "⚠ MinMaxScaler does not support sample_weight\n",
@@ -553,14 +604,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 306.08it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 312.28it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ MiniBatchKMeans: (p_value: 0.003\n",
+      "❌ MiniBatchKMeans: (p_value: 0.016\n",
       "⚠ MiniBatchNMF does not support sample_weight\n",
       "⚠ MiniBatchSparsePCA does not support sample_weight\n",
       "⚠ MissingIndicator does not support sample_weight\n",
@@ -576,8 +627,21 @@
       "⚠ NearestCentroid does not support sample_weight\n",
       "⚠ NeighborhoodComponentsAnalysis does not support sample_weight\n",
       "⚠ Normalizer does not support sample_weight\n",
-      "Evaluating NuSVC(probability=True)\n",
-      "❌ NuSVC(probability=True) error with: index 88 is out of bounds for axis 0 with size 67\n",
+      "Evaluating NuSVC(probability=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 312.31it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ NuSVC: (p_value: 0.000\n",
       "❌ NuSVR() failed the deterministic check\n",
       "⚠ Nystroem does not support sample_weight\n",
       "⚠ OPTICS does not support sample_weight\n",
@@ -602,7 +666,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 589.59it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 571.10it/s]\n"
      ]
     },
     {
@@ -624,7 +688,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  7%|▋         | 2/30 [00:00<00:01, 22.96it/s]\n"
+      "  7%|▋         | 2/30 [00:00<00:01, 27.71it/s]\n"
      ]
     },
     {
@@ -638,8 +702,21 @@
       "⚠ RadiusNeighborsClassifier does not support sample_weight\n",
       "⚠ RadiusNeighborsRegressor does not support sample_weight\n",
       "⚠ RadiusNeighborsTransformer does not support sample_weight\n",
-      "Evaluating RandomForestClassifier()\n",
-      "❌ RandomForestClassifier() error with: index 90 is out of bounds for axis 0 with size 79\n",
+      "Evaluating RandomForestClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:02<00:00, 11.84it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RandomForestClassifier: (p_value: 0.000\n",
       "Evaluating RandomForestRegressor(max_features=0.5)\n"
      ]
     },
@@ -647,7 +724,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 12.49it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 12.23it/s]\n"
      ]
     },
     {
@@ -662,14 +739,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 83.41it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 92.92it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomTreesEmbedding: (p_value: 0.003\n",
+      "❌ RandomTreesEmbedding: (p_value: 0.035\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(solver='sag')\n"
      ]
@@ -678,7 +755,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 198.97it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 201.73it/s]\n"
      ]
     },
     {
@@ -687,21 +764,8 @@
      "text": [
       "❌ Ridge: (p_value: 0.000\n",
       "✅ RidgeCV() passed the deterministic check\n",
-      "Evaluating RidgeClassifier(solver='saga')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 56.22it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ RidgeClassifier: (p_value: 0.000\n",
+      "Evaluating RidgeClassifier(solver='saga')\n",
+      "❌ RidgeClassifier(solver='saga') error with: Floating-point under-/overflow occurred at epoch #820. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "✅ RidgeClassifierCV() passed the deterministic check\n",
       "⚠ RobustScaler does not support sample_weight\n",
       "Evaluating SGDClassifier()\n"
@@ -711,7 +775,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 247.71it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 520.58it/s]\n"
      ]
     },
     {
@@ -726,7 +790,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 285.30it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 745.77it/s]\n"
      ]
     },
     {
@@ -741,7 +805,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 429.04it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 575.30it/s]"
      ]
     },
     {
@@ -779,6 +843,13 @@
       "⚠ VarianceThreshold does not support sample_weight\n",
       "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
       "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -863,9 +934,9 @@
      "text": [
       "✅ 19 passed the deterministic test\n",
       "❌ 4 failed the deterministic test\n",
-      "✅ 0 passed the statistical test\n",
-      "❌ 32 failed the statistical test\n",
-      "❌ 7 other errors\n",
+      "✅ 13 passed the statistical test\n",
+      "❌ 24 failed the statistical test\n",
+      "❌ 2 other errors\n",
       "⚠ 112 estimators lack sample_weight support\n"
      ]
     }
@@ -935,196 +1006,226 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>AdaBoostClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.537906e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>SGDClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>2.518945e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>2.005083e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>Perceptron</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>8.087763e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>MLPRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.310955e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>MLPClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>5.388831e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>LogisticRegression</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>LinearSVR</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>LinearSVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>2.011309e-15</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>LassoCV</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>SGDRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>5.016999e-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>HistGradientBoostingRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>9.234125e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>HistGradientBoostingClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.015291e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>KBinsDiscretizer</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>5.901383e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>GradientBoostingClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>7.402059e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>BaggingClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>8.091668e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaggingRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>4.884640e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>5.088363e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>ElasticNet</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31</th>\n",
+       "      <th>36</th>\n",
        "      <td>SVC</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>4.748435e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>ExtraTreesClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>6.523289e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>7.076172e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>ElasticNetCV</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>DecisionTreeRegressor</td>\n",
-       "      <td>4.326944e-08</td>\n",
-       "      <td>1.239040e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>RidgeClassifier</td>\n",
-       "      <td>2.500012e-07</td>\n",
-       "      <td>2.406156e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>Ridge</td>\n",
-       "      <td>1.275006e-06</td>\n",
-       "      <td>2.282408e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>5.795482e-06</td>\n",
-       "      <td>5.402599e-01</td>\n",
+       "      <td>1.936182e-07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
-       "      <td>KMeans</td>\n",
-       "      <td>2.366488e-05</td>\n",
-       "      <td>1.031610e-01</td>\n",
+       "      <td>HistGradientBoostingClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.497040e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>8.737804e-05</td>\n",
-       "      <td>2.495192e-01</td>\n",
+       "      <th>21</th>\n",
+       "      <td>LassoCV</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>3.078713e-12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>LinearSVC</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>9.986993e-05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>NuSVC</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>5.701363e-13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>HistGradientBoostingRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.254089e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>RandomForestClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>9.786975e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>Perceptron</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>3.210785e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>34</th>\n",
+       "      <td>SGDClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.217192e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.000868e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>SGDRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.143213e-04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>9.236091e-11</td>\n",
+       "      <td>9.646186e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BaggingRegressor</td>\n",
+       "      <td>8.466416e-10</td>\n",
+       "      <td>2.260574e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>Ridge</td>\n",
+       "      <td>2.500012e-07</td>\n",
+       "      <td>2.203853e-04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingClassifier</td>\n",
+       "      <td>2.500012e-07</td>\n",
+       "      <td>4.568466e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>2.366488e-05</td>\n",
+       "      <td>5.480022e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>23</th>\n",
-       "      <td>MiniBatchKMeans</td>\n",
+       "      <td>LinearSVR</td>\n",
        "      <td>2.530062e-03</td>\n",
-       "      <td>3.900416e-01</td>\n",
+       "      <td>1.800381e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>26</th>\n",
+       "      <th>4</th>\n",
+       "      <td>BisectingKMeans</td>\n",
+       "      <td>6.548396e-03</td>\n",
+       "      <td>5.054111e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>MiniBatchKMeans</td>\n",
+       "      <td>1.564339e-02</td>\n",
+       "      <td>4.651244e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>KBinsDiscretizer</td>\n",
+       "      <td>1.564339e-02</td>\n",
+       "      <td>5.487411e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
+       "      <td>1.564339e-02</td>\n",
+       "      <td>5.376123e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
+       "      <td>1.564339e-02</td>\n",
+       "      <td>8.063199e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32</th>\n",
        "      <td>RandomTreesEmbedding</td>\n",
-       "      <td>2.530062e-03</td>\n",
-       "      <td>3.509686e-01</td>\n",
+       "      <td>3.458008e-02</td>\n",
+       "      <td>5.597634e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>KMeans</td>\n",
+       "      <td>3.458008e-02</td>\n",
+       "      <td>5.631018e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AdaBoostRegressor</td>\n",
+       "      <td>1.350035e-01</td>\n",
+       "      <td>6.362048e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
+       "      <td>2.390730e-01</td>\n",
+       "      <td>8.485334e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>GradientBoostingClassifier</td>\n",
+       "      <td>3.929450e-01</td>\n",
+       "      <td>8.336796e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>Lasso</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
        "      <td>DummyClassifier</td>\n",
-       "      <td>3.458008e-02</td>\n",
-       "      <td>6.016999e-01</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>ExtraTreeClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>ElasticNetCV</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>ExtraTreesClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AdaBoostClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000e+00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1132,38 +1233,43 @@
       ],
       "text/plain": [
        "                    estimator_name   min_p_value  mean_p_value\n",
-       "0               AdaBoostClassifier  1.691123e-17  1.537906e-02\n",
-       "29                   SGDClassifier  1.691123e-17  2.518945e-04\n",
-       "25           RandomForestRegressor  1.691123e-17  2.005083e-02\n",
-       "24                      Perceptron  1.691123e-17  8.087763e-03\n",
-       "22                    MLPRegressor  1.691123e-17  1.310955e-02\n",
-       "21                   MLPClassifier  1.691123e-17  5.388831e-02\n",
-       "20              LogisticRegression  1.691123e-17  1.691123e-17\n",
-       "19                       LinearSVR  1.691123e-17  1.691123e-17\n",
-       "18                       LinearSVC  1.691123e-17  2.011309e-15\n",
-       "17                         LassoCV  1.691123e-17  1.691123e-17\n",
-       "30                    SGDRegressor  1.691123e-17  5.016999e-17\n",
-       "14   HistGradientBoostingRegressor  1.691123e-17  9.234125e-03\n",
-       "13  HistGradientBoostingClassifier  1.691123e-17  1.015291e-02\n",
-       "15                KBinsDiscretizer  1.691123e-17  5.901383e-03\n",
-       "11      GradientBoostingClassifier  1.691123e-17  7.402059e-04\n",
-       "1                BaggingClassifier  1.691123e-17  8.091668e-02\n",
-       "2                 BaggingRegressor  1.691123e-17  4.884640e-02\n",
-       "12       GradientBoostingRegressor  1.691123e-17  5.088363e-02\n",
-       "6                       ElasticNet  1.691123e-17  1.691123e-17\n",
-       "31                             SVC  1.691123e-17  4.748435e-03\n",
-       "9             ExtraTreesClassifier  1.691123e-17  6.523289e-02\n",
-       "10             ExtraTreesRegressor  1.691123e-17  7.076172e-02\n",
-       "7                     ElasticNetCV  1.691123e-17  1.691123e-17\n",
-       "4            DecisionTreeRegressor  4.326944e-08  1.239040e-01\n",
-       "28                 RidgeClassifier  2.500012e-07  2.406156e-04\n",
-       "27                           Ridge  1.275006e-06  2.282408e-04\n",
-       "3           DecisionTreeClassifier  5.795482e-06  5.402599e-01\n",
-       "16                          KMeans  2.366488e-05  1.031610e-01\n",
-       "8               ExtraTreeRegressor  8.737804e-05  2.495192e-01\n",
-       "23                 MiniBatchKMeans  2.530062e-03  3.900416e-01\n",
-       "26            RandomTreesEmbedding  2.530062e-03  3.509686e-01\n",
-       "5                  DummyClassifier  3.458008e-02  6.016999e-01"
+       "36                             SVC  1.691123e-17  1.936182e-07\n",
+       "16  HistGradientBoostingClassifier  1.691123e-17  1.497040e-02\n",
+       "21                         LassoCV  1.691123e-17  3.078713e-12\n",
+       "22                       LinearSVC  1.691123e-17  9.986993e-05\n",
+       "28                           NuSVC  1.691123e-17  5.701363e-13\n",
+       "17   HistGradientBoostingRegressor  1.691123e-17  2.254089e-03\n",
+       "30          RandomForestClassifier  1.691123e-17  9.786975e-02\n",
+       "29                      Perceptron  1.691123e-17  3.210785e-03\n",
+       "34                   SGDClassifier  1.691123e-17  1.217192e-03\n",
+       "31           RandomForestRegressor  1.691123e-17  1.000868e-01\n",
+       "35                    SGDRegressor  1.691123e-17  1.143213e-04\n",
+       "24              LogisticRegression  9.236091e-11  9.646186e-02\n",
+       "3                 BaggingRegressor  8.466416e-10  2.260574e-01\n",
+       "33                           Ridge  2.500012e-07  2.203853e-04\n",
+       "2                BaggingClassifier  2.500012e-07  4.568466e-01\n",
+       "6            DecisionTreeRegressor  2.366488e-05  5.480022e-01\n",
+       "23                       LinearSVR  2.530062e-03  1.800381e-01\n",
+       "4                  BisectingKMeans  6.548396e-03  5.054111e-01\n",
+       "27                 MiniBatchKMeans  1.564339e-02  4.651244e-01\n",
+       "18                KBinsDiscretizer  1.564339e-02  5.487411e-01\n",
+       "13             ExtraTreesRegressor  1.564339e-02  5.376123e-01\n",
+       "11              ExtraTreeRegressor  1.564339e-02  8.063199e-01\n",
+       "32            RandomTreesEmbedding  3.458008e-02  5.597634e-01\n",
+       "19                          KMeans  3.458008e-02  5.631018e-01\n",
+       "1                AdaBoostRegressor  1.350035e-01  6.362048e-01\n",
+       "15       GradientBoostingRegressor  2.390730e-01  8.485334e-01\n",
+       "14      GradientBoostingClassifier  3.929450e-01  8.336796e-01\n",
+       "20                           Lasso  1.000000e+00  1.000000e+00\n",
+       "5           DecisionTreeClassifier  1.000000e+00  1.000000e+00\n",
+       "7                  DummyClassifier  1.000000e+00  1.000000e+00\n",
+       "10             ExtraTreeClassifier  1.000000e+00  1.000000e+00\n",
+       "9                     ElasticNetCV  1.000000e+00  1.000000e+00\n",
+       "26                    MLPRegressor  1.000000e+00  1.000000e+00\n",
+       "25                   MLPClassifier  1.000000e+00  1.000000e+00\n",
+       "12            ExtraTreesClassifier  1.000000e+00  1.000000e+00\n",
+       "8                       ElasticNet  1.000000e+00  1.000000e+00\n",
+       "0               AdaBoostClassifier  1.000000e+00  1.000000e+00"
       ]
      },
      "execution_count": 7,

--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -127,7 +127,8 @@
      "output_type": "stream",
      "text": [
       "⚠ ARDRegression does not support sample_weight\n",
-      "Evaluating AdaBoostClassifier(estimator=DecisionTreeClassifier(max_depth=1,\n",
+      "Evaluating AdaBoostClassifier(estimator=DecisionTreeClassifier(class_weight='balanced',\n",
+      "                                                    max_depth=1,\n",
       "                                                    max_features=0.5))\n"
      ]
     },
@@ -135,14 +136,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 19.91it/s]\n"
+      " 63%|██████▎   | 19/30 [00:00<00:00, 23.77it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostClassifier: (p_value: 1.000\n",
+      "❌ AdaBoostClassifier(estimator=DecisionTreeClassifier(class_weight='balanced',\n",
+      "                                                    max_depth=1,\n",
+      "                                                    max_features=0.5)) error with: BaseClassifier in AdaBoostClassifier ensemble is worse than random, ensemble can not be fit.\n",
       "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
       "                                                  max_features=0.5))\n"
      ]
@@ -151,14 +154,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 88.80it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 70.41it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostRegressor: (p_value: 0.135\n",
+      "❌ AdaBoostRegressor: (p_value: 0.035\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -169,7 +172,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 73.29it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 66.60it/s]\n"
      ]
     },
     {
@@ -184,7 +187,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 74.85it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 73.64it/s]\n"
      ]
     },
     {
@@ -204,7 +207,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 403.63it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 398.98it/s]\n"
      ]
     },
     {
@@ -219,21 +222,21 @@
       "⚠ ColumnTransformer does not support sample_weight\n",
       "✅ ComplementNB() passed the deterministic check\n",
       "✅ DBSCAN() passed the deterministic check\n",
-      "Evaluating DecisionTreeClassifier(max_features=0.5)\n"
+      "Evaluating DecisionTreeClassifier(class_weight='balanced', max_features=0.5)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1114.62it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 893.71it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeClassifier: (p_value: 1.000\n",
+      "✅ DecisionTreeClassifier: (p_value: 0.958\n",
       "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
      ]
     },
@@ -241,14 +244,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1113.71it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1131.64it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DecisionTreeRegressor: (p_value: 0.000\n",
+      "❌ DecisionTreeRegressor: (p_value: 0.001\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -258,7 +261,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 2173.44it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 2156.57it/s]\n"
      ]
     },
     {
@@ -274,7 +277,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1121.12it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1121.36it/s]\n"
      ]
     },
     {
@@ -289,7 +292,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 57.60it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 56.62it/s]\n"
      ]
     },
     {
@@ -304,7 +307,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1146.80it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1129.65it/s]\n"
      ]
     },
     {
@@ -319,14 +322,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1172.46it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1137.00it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreeRegressor: (p_value: 0.016\n",
+      "✅ ExtraTreeRegressor: (p_value: 0.071\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -334,7 +337,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 15.09it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 14.66it/s]\n"
      ]
     },
     {
@@ -349,14 +352,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 16.27it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 16.37it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreesRegressor: (p_value: 0.016\n",
+      "❌ ExtraTreesRegressor: (p_value: 0.000\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -377,14 +380,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:05<00:00,  5.85it/s]\n"
+      "100%|██████████| 30/30 [00:04<00:00,  6.43it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingClassifier: (p_value: 0.393\n",
+      "✅ GradientBoostingClassifier: (p_value: 0.239\n",
       "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -392,14 +395,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 31.90it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 30.10it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingRegressor: (p_value: 0.239\n",
+      "✅ GradientBoostingRegressor: (p_value: 0.135\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -409,7 +412,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 18.53it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 16.97it/s]\n"
      ]
     },
     {
@@ -424,7 +427,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 55.40it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 45.74it/s]\n"
      ]
     },
     {
@@ -444,14 +447,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 429.58it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 376.60it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ KBinsDiscretizer: (p_value: 0.016\n",
+      "✅ KBinsDiscretizer: (p_value: 0.071\n",
       "Evaluating KMeans(n_clusters=10)\n"
      ]
     },
@@ -459,14 +462,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 569.43it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 524.90it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ KMeans: (p_value: 0.035\n",
+      "❌ KMeans: (p_value: 0.016\n",
       "⚠ KNNImputer does not support sample_weight\n",
       "⚠ KNeighborsClassifier does not support sample_weight\n",
       "⚠ KNeighborsRegressor does not support sample_weight\n",
@@ -487,7 +490,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1067.04it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 994.14it/s]\n"
      ]
     },
     {
@@ -502,7 +505,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 57.27it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 54.61it/s]\n"
      ]
     },
     {
@@ -523,7 +526,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 80.53it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 126.74it/s]\n"
      ]
     },
     {
@@ -538,14 +541,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1475.15it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 322.23it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LinearSVR: (p_value: 0.003\n",
+      "❌ LinearSVR: (p_value: 0.000\n",
       "⚠ LocallyLinearEmbedding does not support sample_weight\n",
       "Evaluating LogisticRegression(dual=True, max_iter=10000, solver='liblinear')\n"
      ]
@@ -554,7 +557,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 316.50it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 339.74it/s]\n"
      ]
     },
     {
@@ -570,7 +573,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 17.10it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 17.01it/s]\n"
      ]
     },
     {
@@ -585,7 +588,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 20.85it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 18.71it/s]\n"
      ]
     },
     {
@@ -604,14 +607,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 312.28it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 304.74it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ MiniBatchKMeans: (p_value: 0.016\n",
+      "❌ MiniBatchKMeans: (p_value: 0.007\n",
       "⚠ MiniBatchNMF does not support sample_weight\n",
       "⚠ MiniBatchSparsePCA does not support sample_weight\n",
       "⚠ MissingIndicator does not support sample_weight\n",
@@ -634,7 +637,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 312.31it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 323.12it/s]\n"
      ]
     },
     {
@@ -666,7 +669,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 571.10it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 561.88it/s]\n"
      ]
     },
     {
@@ -688,7 +691,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  7%|▋         | 2/30 [00:00<00:01, 27.71it/s]\n"
+      " 47%|████▋     | 14/30 [00:00<00:00, 41.78it/s]\n"
      ]
     },
     {
@@ -709,7 +712,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 11.84it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 11.49it/s]\n"
      ]
     },
     {
@@ -724,7 +727,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 12.23it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 12.35it/s]\n"
      ]
     },
     {
@@ -739,14 +742,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 92.92it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 95.13it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomTreesEmbedding: (p_value: 0.035\n",
+      "✅ RandomTreesEmbedding: (p_value: 0.071\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(solver='sag')\n"
      ]
@@ -755,7 +758,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 201.73it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 200.56it/s]\n"
      ]
     },
     {
@@ -764,8 +767,21 @@
      "text": [
       "❌ Ridge: (p_value: 0.000\n",
       "✅ RidgeCV() passed the deterministic check\n",
-      "Evaluating RidgeClassifier(solver='saga')\n",
-      "❌ RidgeClassifier(solver='saga') error with: Floating-point under-/overflow occurred at epoch #820. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Evaluating RidgeClassifier(solver='saga')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 17%|█▋        | 5/30 [00:00<00:00, 62.34it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RidgeClassifier(solver='saga') error with: Floating-point under-/overflow occurred at epoch #989. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "✅ RidgeClassifierCV() passed the deterministic check\n",
       "⚠ RobustScaler does not support sample_weight\n",
       "Evaluating SGDClassifier()\n"
@@ -775,7 +791,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 520.58it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 525.43it/s]\n"
      ]
     },
     {
@@ -790,7 +806,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 745.77it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 826.47it/s]\n"
      ]
     },
     {
@@ -805,7 +821,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 575.30it/s]"
+      "100%|██████████| 30/30 [00:00<00:00, 198.29it/s]\n"
      ]
     },
     {
@@ -843,13 +859,6 @@
       "⚠ VarianceThreshold does not support sample_weight\n",
       "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
       "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
      ]
     }
    ],
@@ -934,9 +943,9 @@
      "text": [
       "✅ 19 passed the deterministic test\n",
       "❌ 4 failed the deterministic test\n",
-      "✅ 13 passed the statistical test\n",
-      "❌ 24 failed the statistical test\n",
-      "❌ 2 other errors\n",
+      "✅ 14 passed the statistical test\n",
+      "❌ 22 failed the statistical test\n",
+      "❌ 3 other errors\n",
       "⚠ 112 estimators lack sample_weight support\n"
      ]
     }
@@ -1006,226 +1015,220 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>36</th>\n",
+       "      <th>35</th>\n",
        "      <td>SVC</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>1.936182e-07</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>HistGradientBoostingClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.497040e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>LassoCV</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>3.078713e-12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>LinearSVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>9.986993e-05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>NuSVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>5.701363e-13</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>HistGradientBoostingRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>2.254089e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>RandomForestClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>9.786975e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>Perceptron</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>3.210785e-03</td>\n",
+       "      <td>0.000006</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>34</th>\n",
-       "      <td>SGDClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.217192e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.000868e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>35</th>\n",
        "      <td>SGDRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>1.143213e-04</td>\n",
+       "      <td>0.000010</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>LogisticRegression</td>\n",
-       "      <td>9.236091e-11</td>\n",
-       "      <td>9.646186e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>BaggingRegressor</td>\n",
-       "      <td>8.466416e-10</td>\n",
-       "      <td>2.260574e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>33</th>\n",
-       "      <td>Ridge</td>\n",
-       "      <td>2.500012e-07</td>\n",
-       "      <td>2.203853e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaggingClassifier</td>\n",
-       "      <td>2.500012e-07</td>\n",
-       "      <td>4.568466e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>DecisionTreeRegressor</td>\n",
-       "      <td>2.366488e-05</td>\n",
-       "      <td>5.480022e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>LinearSVR</td>\n",
-       "      <td>2.530062e-03</td>\n",
-       "      <td>1.800381e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>BisectingKMeans</td>\n",
-       "      <td>6.548396e-03</td>\n",
-       "      <td>5.054111e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>MiniBatchKMeans</td>\n",
-       "      <td>1.564339e-02</td>\n",
-       "      <td>4.651244e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>KBinsDiscretizer</td>\n",
-       "      <td>1.564339e-02</td>\n",
-       "      <td>5.487411e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>1.564339e-02</td>\n",
-       "      <td>5.376123e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>1.564339e-02</td>\n",
-       "      <td>8.063199e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>32</th>\n",
-       "      <td>RandomTreesEmbedding</td>\n",
-       "      <td>3.458008e-02</td>\n",
-       "      <td>5.597634e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>KMeans</td>\n",
-       "      <td>3.458008e-02</td>\n",
-       "      <td>5.631018e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>AdaBoostRegressor</td>\n",
-       "      <td>1.350035e-01</td>\n",
-       "      <td>6.362048e-01</td>\n",
+       "      <th>16</th>\n",
+       "      <td>HistGradientBoostingRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.132291</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>15</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>2.390730e-01</td>\n",
-       "      <td>8.485334e-01</td>\n",
+       "      <td>HistGradientBoostingClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.052410</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>GradientBoostingClassifier</td>\n",
-       "      <td>3.929450e-01</td>\n",
-       "      <td>8.336796e-01</td>\n",
+       "      <th>21</th>\n",
+       "      <td>LinearSVC</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.000003</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>Perceptron</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.003939</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.119047</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>NuSVC</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.019803</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>SGDClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.006417</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>20</th>\n",
-       "      <td>Lasso</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>LassoCV</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>0.026932</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>29</th>\n",
+       "      <td>RandomForestClassifier</td>\n",
+       "      <td>1.014674e-15</td>\n",
+       "      <td>0.233731</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>DummyClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>23</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>1.014674e-15</td>\n",
+       "      <td>0.124649</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>ExtraTreeClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>1</th>\n",
+       "      <td>BaggingClassifier</td>\n",
+       "      <td>8.246510e-12</td>\n",
+       "      <td>0.292787</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>ElasticNetCV</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>22</th>\n",
+       "      <td>LinearSVR</td>\n",
+       "      <td>8.466416e-10</td>\n",
+       "      <td>0.112182</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>MLPRegressor</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingRegressor</td>\n",
+       "      <td>6.531236e-09</td>\n",
+       "      <td>0.127654</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>MLPClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>32</th>\n",
+       "      <td>Ridge</td>\n",
+       "      <td>6.531236e-09</td>\n",
+       "      <td>0.000180</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
-       "      <td>ExtraTreesClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
+       "      <td>8.737804e-05</td>\n",
+       "      <td>0.615249</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>ElasticNet</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>5</th>\n",
+       "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>8.995777e-04</td>\n",
+       "      <td>0.787147</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>MiniBatchKMeans</td>\n",
+       "      <td>6.548396e-03</td>\n",
+       "      <td>0.426149</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BisectingKMeans</td>\n",
+       "      <td>6.548396e-03</td>\n",
+       "      <td>0.488554</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>KMeans</td>\n",
+       "      <td>1.564339e-02</td>\n",
+       "      <td>0.563081</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>AdaBoostClassifier</td>\n",
+       "      <td>AdaBoostRegressor</td>\n",
+       "      <td>3.458008e-02</td>\n",
+       "      <td>0.566948</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
+       "      <td>7.088799e-02</td>\n",
+       "      <td>0.704404</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>RandomTreesEmbedding</td>\n",
+       "      <td>7.088799e-02</td>\n",
+       "      <td>0.593194</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>KBinsDiscretizer</td>\n",
+       "      <td>7.088799e-02</td>\n",
+       "      <td>0.554314</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
+       "      <td>1.350035e-01</td>\n",
+       "      <td>0.726652</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>GradientBoostingClassifier</td>\n",
+       "      <td>2.390730e-01</td>\n",
+       "      <td>0.732647</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
+       "      <td>9.578463e-01</td>\n",
+       "      <td>0.995553</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>MLPClassifier</td>\n",
        "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>MLPRegressor</td>\n",
        "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>ExtraTreesClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>ExtraTreeClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>ElasticNetCV</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>DummyClassifier</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>Lasso</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1233,43 +1236,42 @@
       ],
       "text/plain": [
        "                    estimator_name   min_p_value  mean_p_value\n",
-       "36                             SVC  1.691123e-17  1.936182e-07\n",
-       "16  HistGradientBoostingClassifier  1.691123e-17  1.497040e-02\n",
-       "21                         LassoCV  1.691123e-17  3.078713e-12\n",
-       "22                       LinearSVC  1.691123e-17  9.986993e-05\n",
-       "28                           NuSVC  1.691123e-17  5.701363e-13\n",
-       "17   HistGradientBoostingRegressor  1.691123e-17  2.254089e-03\n",
-       "30          RandomForestClassifier  1.691123e-17  9.786975e-02\n",
-       "29                      Perceptron  1.691123e-17  3.210785e-03\n",
-       "34                   SGDClassifier  1.691123e-17  1.217192e-03\n",
-       "31           RandomForestRegressor  1.691123e-17  1.000868e-01\n",
-       "35                    SGDRegressor  1.691123e-17  1.143213e-04\n",
-       "24              LogisticRegression  9.236091e-11  9.646186e-02\n",
-       "3                 BaggingRegressor  8.466416e-10  2.260574e-01\n",
-       "33                           Ridge  2.500012e-07  2.203853e-04\n",
-       "2                BaggingClassifier  2.500012e-07  4.568466e-01\n",
-       "6            DecisionTreeRegressor  2.366488e-05  5.480022e-01\n",
-       "23                       LinearSVR  2.530062e-03  1.800381e-01\n",
-       "4                  BisectingKMeans  6.548396e-03  5.054111e-01\n",
-       "27                 MiniBatchKMeans  1.564339e-02  4.651244e-01\n",
-       "18                KBinsDiscretizer  1.564339e-02  5.487411e-01\n",
-       "13             ExtraTreesRegressor  1.564339e-02  5.376123e-01\n",
-       "11              ExtraTreeRegressor  1.564339e-02  8.063199e-01\n",
-       "32            RandomTreesEmbedding  3.458008e-02  5.597634e-01\n",
-       "19                          KMeans  3.458008e-02  5.631018e-01\n",
-       "1                AdaBoostRegressor  1.350035e-01  6.362048e-01\n",
-       "15       GradientBoostingRegressor  2.390730e-01  8.485334e-01\n",
-       "14      GradientBoostingClassifier  3.929450e-01  8.336796e-01\n",
-       "20                           Lasso  1.000000e+00  1.000000e+00\n",
-       "5           DecisionTreeClassifier  1.000000e+00  1.000000e+00\n",
-       "7                  DummyClassifier  1.000000e+00  1.000000e+00\n",
-       "10             ExtraTreeClassifier  1.000000e+00  1.000000e+00\n",
-       "9                     ElasticNetCV  1.000000e+00  1.000000e+00\n",
-       "26                    MLPRegressor  1.000000e+00  1.000000e+00\n",
-       "25                   MLPClassifier  1.000000e+00  1.000000e+00\n",
-       "12            ExtraTreesClassifier  1.000000e+00  1.000000e+00\n",
-       "8                       ElasticNet  1.000000e+00  1.000000e+00\n",
-       "0               AdaBoostClassifier  1.000000e+00  1.000000e+00"
+       "35                             SVC  1.691123e-17      0.000006\n",
+       "34                    SGDRegressor  1.691123e-17      0.000010\n",
+       "16   HistGradientBoostingRegressor  1.691123e-17      0.132291\n",
+       "15  HistGradientBoostingClassifier  1.691123e-17      0.052410\n",
+       "21                       LinearSVC  1.691123e-17      0.000003\n",
+       "28                      Perceptron  1.691123e-17      0.003939\n",
+       "30           RandomForestRegressor  1.691123e-17      0.119047\n",
+       "27                           NuSVC  1.691123e-17      0.019803\n",
+       "33                   SGDClassifier  1.691123e-17      0.006417\n",
+       "20                         LassoCV  1.691123e-17      0.026932\n",
+       "29          RandomForestClassifier  1.014674e-15      0.233731\n",
+       "23              LogisticRegression  1.014674e-15      0.124649\n",
+       "1                BaggingClassifier  8.246510e-12      0.292787\n",
+       "22                       LinearSVR  8.466416e-10      0.112182\n",
+       "2                 BaggingRegressor  6.531236e-09      0.127654\n",
+       "32                           Ridge  6.531236e-09      0.000180\n",
+       "12             ExtraTreesRegressor  8.737804e-05      0.615249\n",
+       "5            DecisionTreeRegressor  8.995777e-04      0.787147\n",
+       "26                 MiniBatchKMeans  6.548396e-03      0.426149\n",
+       "3                  BisectingKMeans  6.548396e-03      0.488554\n",
+       "18                          KMeans  1.564339e-02      0.563081\n",
+       "0                AdaBoostRegressor  3.458008e-02      0.566948\n",
+       "10              ExtraTreeRegressor  7.088799e-02      0.704404\n",
+       "31            RandomTreesEmbedding  7.088799e-02      0.593194\n",
+       "17                KBinsDiscretizer  7.088799e-02      0.554314\n",
+       "14       GradientBoostingRegressor  1.350035e-01      0.726652\n",
+       "13      GradientBoostingClassifier  2.390730e-01      0.732647\n",
+       "4           DecisionTreeClassifier  9.578463e-01      0.995553\n",
+       "24                   MLPClassifier  1.000000e+00      1.000000\n",
+       "25                    MLPRegressor  1.000000e+00      1.000000\n",
+       "11            ExtraTreesClassifier  1.000000e+00      1.000000\n",
+       "9              ExtraTreeClassifier  1.000000e+00      1.000000\n",
+       "8                     ElasticNetCV  1.000000e+00      1.000000\n",
+       "7                       ElasticNet  1.000000e+00      1.000000\n",
+       "6                  DummyClassifier  1.000000e+00      1.000000\n",
+       "19                           Lasso  1.000000e+00      1.000000"
       ]
      },
      "execution_count": 7,

--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -28,16 +28,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "meson-python: building scikit-learn: /Users/shrutinath/micromamba/envs/scikit-learn/bin/ninja\n",
-      "[1/2] Compiling C object sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o\n",
-      "\u001b[31mFAILED: \u001b[0msklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o \n",
-      "arm64-apple-darwin20.0.0-clang -Isklearn/tree/_partitioner.cpython-312-darwin.so.p -Isklearn/tree -I../../sklearn/tree -I../../../../micromamba/envs/scikit-learn/lib/python3.12/site-packages/numpy/_core/include -Isklearn -Isklearn/utils -I/Users/shrutinath/micromamba/envs/scikit-learn/include/python3.12 -fvisibility=hidden -fdiagnostics-color=always -DNDEBUG -Wall -Winvalid-pch -std=c11 -O3 -Wno-unused-but-set-variable -Wno-unused-function -Wno-conversion -Wno-misleading-indentation -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -isystem /Users/shrutinath/micromamba/envs/scikit-learn/include -D_FORTIFY_SOURCE=2 -isystem /Users/shrutinath/micromamba/envs/scikit-learn/include -DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION -MD -MQ sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o -MF sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o.d -o sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o -c sklearn/tree/_partitioner.cpython-312-darwin.so.p/sklearn/tree/_partitioner.pyx.c\n",
-      "In file included from sklearn/tree/_partitioner.cpython-312-darwin.so.p/sklearn/tree/_partitioner.pyx.c:16:\n",
-      "\u001b[1m/Users/shrutinath/micromamba/envs/scikit-learn/include/python3.12/Python.h:23:12: \u001b[0m\u001b[0;1;31mfatal error: \u001b[0m\u001b[1m'stdlib.h' file not found\u001b[0m\n",
-      "#  include <stdlib.h>\n",
-      "\u001b[0;1;32m           ^~~~~~~~~~\n",
-      "\u001b[0m1 error generated.\n",
-      "ninja: build stopped: subcommand failed.\n",
       "\n",
       "System:\n",
       "    python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:13:44) [Clang 16.0.6 ]\n",
@@ -145,7 +135,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 20.14it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 20.06it/s]\n"
      ]
     },
     {
@@ -156,7 +146,7 @@
       "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
       "                                                  max_features=0.5))\n",
       "❌ AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
-      "                                                  max_features=0.5)) error with: index 95 is out of bounds for axis 0 with size 95\n",
+      "                                                  max_features=0.5)) error with: index 97 is out of bounds for axis 0 with size 94\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -167,7 +157,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 70.83it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 62.45it/s]\n"
      ]
     },
     {
@@ -182,7 +172,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 45.27it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 72.85it/s]\n"
      ]
     },
     {
@@ -195,21 +185,8 @@
       "⚠ BernoulliRBM does not support sample_weight\n",
       "⚠ Binarizer does not support sample_weight\n",
       "⚠ Birch does not support sample_weight\n",
-      "Evaluating BisectingKMeans()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 431.12it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ BisectingKMeans() error with: cannot reshape array of size 720 into shape (30,30)\n",
+      "Evaluating BisectingKMeans(n_clusters=10)\n",
+      "❌ BisectingKMeans(n_clusters=10) error with: index 90 is out of bounds for axis 0 with size 90\n",
       "⚠ CCA does not support sample_weight\n",
       "✅ CalibratedClassifierCV() passed the deterministic check\n",
       "✅ CategoricalNB() passed the deterministic check\n",
@@ -224,7 +201,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1047.45it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1012.83it/s]\n"
      ]
     },
     {
@@ -239,7 +216,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1114.62it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1098.94it/s]\n"
      ]
     },
     {
@@ -256,14 +233,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 2193.29it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 2160.64it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DummyClassifier: (p_value: 0.808\n",
+      "❌ DummyClassifier: (p_value: 0.035\n",
       "✅ DummyRegressor() passed the deterministic check\n",
       "Evaluating ElasticNet(selection='random')\n"
      ]
@@ -272,7 +249,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1069.70it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1060.00it/s]\n"
      ]
     },
     {
@@ -287,7 +264,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 56.15it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 54.83it/s]\n"
      ]
     },
     {
@@ -295,21 +272,8 @@
      "output_type": "stream",
      "text": [
       "❌ ElasticNetCV: (p_value: 0.000\n",
-      "Evaluating ExtraTreeClassifier()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1142.90it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ ExtraTreeClassifier: (p_value: 0.135\n",
+      "Evaluating ExtraTreeClassifier()\n",
+      "❌ ExtraTreeClassifier() error with: index 95 is out of bounds for axis 0 with size 92\n",
       "Evaluating ExtraTreeRegressor()\n"
      ]
     },
@@ -317,7 +281,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1137.61it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1209.52it/s]\n"
      ]
     },
     {
@@ -332,7 +296,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 15.50it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 15.59it/s]\n"
      ]
     },
     {
@@ -340,8 +304,21 @@
      "output_type": "stream",
      "text": [
       "❌ ExtraTreesClassifier: (p_value: 0.000\n",
-      "Evaluating ExtraTreesRegressor()\n",
-      "❌ ExtraTreesRegressor() error with: index 97 is out of bounds for axis 0 with size 94\n",
+      "Evaluating ExtraTreesRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:01<00:00, 16.38it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ ExtraTreesRegressor: (p_value: 0.000\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -362,7 +339,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:04<00:00,  6.52it/s]\n"
+      "100%|██████████| 30/30 [00:04<00:00,  6.45it/s]\n"
      ]
     },
     {
@@ -377,7 +354,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 31.43it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 31.83it/s]\n"
      ]
     },
     {
@@ -394,7 +371,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 19.50it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 17.57it/s]\n"
      ]
     },
     {
@@ -409,7 +386,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 46.25it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 52.53it/s]\n"
      ]
     },
     {
@@ -429,7 +406,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 639.17it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 422.14it/s]\n"
      ]
     },
     {
@@ -437,21 +414,21 @@
      "output_type": "stream",
      "text": [
       "❌ KBinsDiscretizer: (p_value: 0.000\n",
-      "Evaluating KMeans()\n"
+      "Evaluating KMeans(n_clusters=10)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 576.92it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 578.99it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ KMeans() error with: cannot reshape array of size 720 into shape (30,30)\n",
+      "❌ KMeans: (p_value: 0.000\n",
       "⚠ KNNImputer does not support sample_weight\n",
       "⚠ KNeighborsClassifier does not support sample_weight\n",
       "⚠ KNeighborsRegressor does not support sample_weight\n",
@@ -465,21 +442,8 @@
       "⚠ LabelSpreading does not support sample_weight\n",
       "⚠ Lars does not support sample_weight\n",
       "⚠ LarsCV does not support sample_weight\n",
-      "Evaluating Lasso(selection='random')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1094.05it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ Lasso: (p_value: 0.000\n",
+      "Evaluating Lasso(selection='random')\n",
+      "❌ Lasso(selection='random') error with: index 98 is out of bounds for axis 0 with size 98\n",
       "Evaluating LassoCV(selection='random')\n"
      ]
     },
@@ -487,7 +451,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 48.41it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 55.60it/s]\n"
      ]
     },
     {
@@ -508,7 +472,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 166.35it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 95.71it/s]\n"
      ]
     },
     {
@@ -523,7 +487,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 694.99it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1417.89it/s]\n"
      ]
     },
     {
@@ -539,7 +503,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 360.66it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 287.14it/s]\n"
      ]
     },
     {
@@ -555,7 +519,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 15.94it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 14.95it/s]\n"
      ]
     },
     {
@@ -570,7 +534,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 19.31it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 16.31it/s]\n"
      ]
     },
     {
@@ -582,8 +546,21 @@
       "⚠ MeanShift does not support sample_weight\n",
       "⚠ MinMaxScaler does not support sample_weight\n",
       "⚠ MiniBatchDictionaryLearning does not support sample_weight\n",
-      "Evaluating MiniBatchKMeans(reassignment_ratio=0.9)\n",
-      "❌ MiniBatchKMeans(reassignment_ratio=0.9) error with: index 90 is out of bounds for axis 0 with size 81\n",
+      "Evaluating MiniBatchKMeans(n_clusters=10, reassignment_ratio=0.9)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 306.08it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ MiniBatchKMeans: (p_value: 0.003\n",
       "⚠ MiniBatchNMF does not support sample_weight\n",
       "⚠ MiniBatchSparsePCA does not support sample_weight\n",
       "⚠ MissingIndicator does not support sample_weight\n",
@@ -599,21 +576,8 @@
       "⚠ NearestCentroid does not support sample_weight\n",
       "⚠ NeighborhoodComponentsAnalysis does not support sample_weight\n",
       "⚠ Normalizer does not support sample_weight\n",
-      "Evaluating NuSVC(probability=True)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 364.04it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ NuSVC: (p_value: 0.000\n",
+      "Evaluating NuSVC(probability=True)\n",
+      "❌ NuSVC(probability=True) error with: index 88 is out of bounds for axis 0 with size 67\n",
       "❌ NuSVR() failed the deterministic check\n",
       "⚠ Nystroem does not support sample_weight\n",
       "⚠ OPTICS does not support sample_weight\n",
@@ -638,7 +602,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 588.11it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 589.59it/s]\n"
      ]
     },
     {
@@ -653,7 +617,20 @@
       "⚠ QuadraticDiscriminantAnalysis does not support sample_weight\n",
       "✅ QuantileRegressor() passed the deterministic check\n",
       "⚠ QuantileTransformer does not support sample_weight\n",
-      "Evaluating RANSACRegressor()\n",
+      "Evaluating RANSACRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  7%|▋         | 2/30 [00:00<00:01, 22.96it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "❌ RANSACRegressor() error with: Weights sum to zero, can't be normalized\n",
       "⚠ RBFSampler does not support sample_weight\n",
       "⚠ RFE does not support sample_weight\n",
@@ -661,21 +638,8 @@
       "⚠ RadiusNeighborsClassifier does not support sample_weight\n",
       "⚠ RadiusNeighborsRegressor does not support sample_weight\n",
       "⚠ RadiusNeighborsTransformer does not support sample_weight\n",
-      "Evaluating RandomForestClassifier()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 11.95it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ RandomForestClassifier: (p_value: 0.000\n",
+      "Evaluating RandomForestClassifier()\n",
+      "❌ RandomForestClassifier() error with: index 90 is out of bounds for axis 0 with size 79\n",
       "Evaluating RandomForestRegressor(max_features=0.5)\n"
      ]
     },
@@ -683,7 +647,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 12.88it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 12.49it/s]\n"
      ]
     },
     {
@@ -698,14 +662,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|          | 0/30 [00:00<?, ?it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 83.41it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomTreesEmbedding(n_estimators=10) error with: X has 124 features, but GaussianRandomProjection is expecting 150 features as input.\n",
+      "❌ RandomTreesEmbedding: (p_value: 0.003\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(solver='sag')\n"
      ]
@@ -714,7 +678,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 203.85it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 198.97it/s]\n"
      ]
     },
     {
@@ -730,7 +694,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 68.45it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 56.22it/s]\n"
      ]
     },
     {
@@ -747,7 +711,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 545.51it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 247.71it/s]\n"
      ]
     },
     {
@@ -762,7 +726,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 389.04it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 285.30it/s]\n"
      ]
     },
     {
@@ -770,8 +734,21 @@
      "output_type": "stream",
      "text": [
       "❌ SGDRegressor: (p_value: 0.000\n",
-      "Evaluating SVC(probability=True)\n",
-      "❌ SVC(probability=True) error with: index 84 is out of bounds for axis 0 with size 82\n",
+      "Evaluating SVC(probability=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 429.04it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ SVC: (p_value: 0.000\n",
       "❌ SVR() failed the deterministic check\n",
       "⚠ SelectFdr does not support sample_weight\n",
       "⚠ SelectFpr does not support sample_weight\n",
@@ -877,7 +854,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -886,9 +863,9 @@
      "text": [
       "✅ 19 passed the deterministic test\n",
       "❌ 4 failed the deterministic test\n",
-      "✅ 2 passed the statistical test\n",
-      "❌ 29 failed the statistical test\n",
-      "❌ 8 other errors\n",
+      "✅ 0 passed the statistical test\n",
+      "❌ 32 failed the statistical test\n",
+      "❌ 7 other errors\n",
       "⚠ 112 estimators lack sample_weight support\n"
      ]
     }
@@ -927,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -958,10 +935,46 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>SGDRegressor</td>\n",
+       "      <th>0</th>\n",
+       "      <td>AdaBoostClassifier</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>2.824069e-11</td>\n",
+       "      <td>1.537906e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>SGDClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.518945e-04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.005083e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>Perceptron</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>8.087763e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.310955e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>5.388831e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.691123e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
@@ -973,73 +986,61 @@
        "      <th>18</th>\n",
        "      <td>LinearSVC</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>2.822140e-11</td>\n",
+       "      <td>2.011309e-15</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
        "      <td>LassoCV</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>9.778018e-06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>Lasso</td>\n",
-       "      <td>1.691123e-17</td>\n",
        "      <td>1.691123e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>SGDClassifier</td>\n",
+       "      <th>30</th>\n",
+       "      <td>SGDRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>4.334224e-04</td>\n",
+       "      <td>5.016999e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>HistGradientBoostingRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>2.110373e-02</td>\n",
+       "      <td>9.234125e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>13</th>\n",
        "      <td>HistGradientBoostingClassifier</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>1.020833e-05</td>\n",
+       "      <td>1.015291e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
+       "      <th>15</th>\n",
+       "      <td>KBinsDiscretizer</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>7.487882e-02</td>\n",
+       "      <td>5.901383e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>GradientBoostingClassifier</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>4.981785e-03</td>\n",
+       "      <td>7.402059e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>ExtraTreesClassifier</td>\n",
+       "      <th>1</th>\n",
+       "      <td>BaggingClassifier</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>1.246312e-01</td>\n",
+       "      <td>8.091668e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>MLPRegressor</td>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>2.098852e-02</td>\n",
+       "      <td>4.884640e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>NuSVC</td>\n",
+       "      <th>12</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>2.306223e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>ElasticNetCV</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.691123e-17</td>\n",
+       "      <td>5.088363e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -1048,100 +1049,82 @@
        "      <td>1.691123e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>Perceptron</td>\n",
+       "      <th>31</th>\n",
+       "      <td>SVC</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>6.154257e-03</td>\n",
+       "      <td>4.748435e-03</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>RandomForestClassifier</td>\n",
+       "      <th>9</th>\n",
+       "      <td>ExtraTreesClassifier</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>1.285648e-02</td>\n",
+       "      <td>6.523289e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
+       "      <th>10</th>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>2.456810e-02</td>\n",
+       "      <td>7.076172e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaggingRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>3.902919e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>LogisticRegression</td>\n",
+       "      <th>7</th>\n",
+       "      <td>ElasticNetCV</td>\n",
        "      <td>1.691123e-17</td>\n",
        "      <td>1.691123e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>MLPClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>9.627595e-02</td>\n",
+       "      <th>4</th>\n",
+       "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>4.326944e-08</td>\n",
+       "      <td>1.239040e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>BaggingClassifier</td>\n",
-       "      <td>1.014674e-15</td>\n",
-       "      <td>1.558044e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>AdaBoostClassifier</td>\n",
-       "      <td>5.787024e-13</td>\n",
-       "      <td>5.635884e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>9.236091e-11</td>\n",
-       "      <td>6.052421e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>KBinsDiscretizer</td>\n",
-       "      <td>8.466416e-10</td>\n",
-       "      <td>6.026780e-01</td>\n",
+       "      <th>28</th>\n",
+       "      <td>RidgeClassifier</td>\n",
+       "      <td>2.500012e-07</td>\n",
+       "      <td>2.406156e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>27</th>\n",
        "      <td>Ridge</td>\n",
        "      <td>1.275006e-06</td>\n",
-       "      <td>2.135869e-04</td>\n",
+       "      <td>2.282408e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>RidgeClassifier</td>\n",
-       "      <td>1.275006e-06</td>\n",
-       "      <td>2.749358e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>1.275006e-06</td>\n",
-       "      <td>2.394195e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>DecisionTreeRegressor</td>\n",
+       "      <th>3</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
        "      <td>5.795482e-06</td>\n",
-       "      <td>1.465679e-01</td>\n",
+       "      <td>5.402599e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>KMeans</td>\n",
+       "      <td>2.366488e-05</td>\n",
+       "      <td>1.031610e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>ExtraTreeClassifier</td>\n",
-       "      <td>1.350035e-01</td>\n",
-       "      <td>7.806349e-01</td>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
+       "      <td>8.737804e-05</td>\n",
+       "      <td>2.495192e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>MiniBatchKMeans</td>\n",
+       "      <td>2.530062e-03</td>\n",
+       "      <td>3.900416e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>RandomTreesEmbedding</td>\n",
+       "      <td>2.530062e-03</td>\n",
+       "      <td>3.509686e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>DummyClassifier</td>\n",
-       "      <td>8.079632e-01</td>\n",
-       "      <td>9.879396e-01</td>\n",
+       "      <td>3.458008e-02</td>\n",
+       "      <td>6.016999e-01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1149,40 +1132,41 @@
       ],
       "text/plain": [
        "                    estimator_name   min_p_value  mean_p_value\n",
-       "30                    SGDRegressor  1.691123e-17  2.824069e-11\n",
-       "19                       LinearSVR  1.691123e-17  1.691123e-17\n",
-       "18                       LinearSVC  1.691123e-17  2.822140e-11\n",
-       "17                         LassoCV  1.691123e-17  9.778018e-06\n",
-       "16                           Lasso  1.691123e-17  1.691123e-17\n",
-       "29                   SGDClassifier  1.691123e-17  4.334224e-04\n",
-       "14   HistGradientBoostingRegressor  1.691123e-17  2.110373e-02\n",
-       "13  HistGradientBoostingClassifier  1.691123e-17  1.020833e-05\n",
-       "12       GradientBoostingRegressor  1.691123e-17  7.487882e-02\n",
-       "11      GradientBoostingClassifier  1.691123e-17  4.981785e-03\n",
-       "10            ExtraTreesClassifier  1.691123e-17  1.246312e-01\n",
-       "22                    MLPRegressor  1.691123e-17  2.098852e-02\n",
-       "23                           NuSVC  1.691123e-17  2.306223e-03\n",
-       "7                     ElasticNetCV  1.691123e-17  1.691123e-17\n",
-       "6                       ElasticNet  1.691123e-17  1.691123e-17\n",
-       "24                      Perceptron  1.691123e-17  6.154257e-03\n",
-       "25          RandomForestClassifier  1.691123e-17  1.285648e-02\n",
-       "26           RandomForestRegressor  1.691123e-17  2.456810e-02\n",
-       "2                 BaggingRegressor  1.691123e-17  3.902919e-02\n",
+       "0               AdaBoostClassifier  1.691123e-17  1.537906e-02\n",
+       "29                   SGDClassifier  1.691123e-17  2.518945e-04\n",
+       "25           RandomForestRegressor  1.691123e-17  2.005083e-02\n",
+       "24                      Perceptron  1.691123e-17  8.087763e-03\n",
+       "22                    MLPRegressor  1.691123e-17  1.310955e-02\n",
+       "21                   MLPClassifier  1.691123e-17  5.388831e-02\n",
        "20              LogisticRegression  1.691123e-17  1.691123e-17\n",
-       "21                   MLPClassifier  1.691123e-17  9.627595e-02\n",
-       "1                BaggingClassifier  1.014674e-15  1.558044e-01\n",
-       "0               AdaBoostClassifier  5.787024e-13  5.635884e-02\n",
-       "3           DecisionTreeClassifier  9.236091e-11  6.052421e-01\n",
-       "15                KBinsDiscretizer  8.466416e-10  6.026780e-01\n",
-       "27                           Ridge  1.275006e-06  2.135869e-04\n",
-       "28                 RidgeClassifier  1.275006e-06  2.749358e-04\n",
-       "9               ExtraTreeRegressor  1.275006e-06  2.394195e-01\n",
-       "4            DecisionTreeRegressor  5.795482e-06  1.465679e-01\n",
-       "8              ExtraTreeClassifier  1.350035e-01  7.806349e-01\n",
-       "5                  DummyClassifier  8.079632e-01  9.879396e-01"
+       "19                       LinearSVR  1.691123e-17  1.691123e-17\n",
+       "18                       LinearSVC  1.691123e-17  2.011309e-15\n",
+       "17                         LassoCV  1.691123e-17  1.691123e-17\n",
+       "30                    SGDRegressor  1.691123e-17  5.016999e-17\n",
+       "14   HistGradientBoostingRegressor  1.691123e-17  9.234125e-03\n",
+       "13  HistGradientBoostingClassifier  1.691123e-17  1.015291e-02\n",
+       "15                KBinsDiscretizer  1.691123e-17  5.901383e-03\n",
+       "11      GradientBoostingClassifier  1.691123e-17  7.402059e-04\n",
+       "1                BaggingClassifier  1.691123e-17  8.091668e-02\n",
+       "2                 BaggingRegressor  1.691123e-17  4.884640e-02\n",
+       "12       GradientBoostingRegressor  1.691123e-17  5.088363e-02\n",
+       "6                       ElasticNet  1.691123e-17  1.691123e-17\n",
+       "31                             SVC  1.691123e-17  4.748435e-03\n",
+       "9             ExtraTreesClassifier  1.691123e-17  6.523289e-02\n",
+       "10             ExtraTreesRegressor  1.691123e-17  7.076172e-02\n",
+       "7                     ElasticNetCV  1.691123e-17  1.691123e-17\n",
+       "4            DecisionTreeRegressor  4.326944e-08  1.239040e-01\n",
+       "28                 RidgeClassifier  2.500012e-07  2.406156e-04\n",
+       "27                           Ridge  1.275006e-06  2.282408e-04\n",
+       "3           DecisionTreeClassifier  5.795482e-06  5.402599e-01\n",
+       "16                          KMeans  2.366488e-05  1.031610e-01\n",
+       "8               ExtraTreeRegressor  8.737804e-05  2.495192e-01\n",
+       "23                 MiniBatchKMeans  2.530062e-03  3.900416e-01\n",
+       "26            RandomTreesEmbedding  2.530062e-03  3.509686e-01\n",
+       "5                  DummyClassifier  3.458008e-02  6.016999e-01"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -28,21 +28,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "meson-python: building scikit-learn: /Users/shrutinath/micromamba/envs/scikit-learn/bin/ninja\n",
+      "[1/2] Compiling C object sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o\n",
+      "\u001b[31mFAILED: \u001b[0msklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o \n",
+      "arm64-apple-darwin20.0.0-clang -Isklearn/tree/_partitioner.cpython-312-darwin.so.p -Isklearn/tree -I../../sklearn/tree -I../../../../micromamba/envs/scikit-learn/lib/python3.12/site-packages/numpy/_core/include -Isklearn -Isklearn/utils -I/Users/shrutinath/micromamba/envs/scikit-learn/include/python3.12 -fvisibility=hidden -fdiagnostics-color=always -DNDEBUG -Wall -Winvalid-pch -std=c11 -O3 -Wno-unused-but-set-variable -Wno-unused-function -Wno-conversion -Wno-misleading-indentation -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -isystem /Users/shrutinath/micromamba/envs/scikit-learn/include -D_FORTIFY_SOURCE=2 -isystem /Users/shrutinath/micromamba/envs/scikit-learn/include -DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION -MD -MQ sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o -MF sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o.d -o sklearn/tree/_partitioner.cpython-312-darwin.so.p/meson-generated_sklearn_tree__partitioner.pyx.c.o -c sklearn/tree/_partitioner.cpython-312-darwin.so.p/sklearn/tree/_partitioner.pyx.c\n",
+      "In file included from sklearn/tree/_partitioner.cpython-312-darwin.so.p/sklearn/tree/_partitioner.pyx.c:16:\n",
+      "\u001b[1m/Users/shrutinath/micromamba/envs/scikit-learn/include/python3.12/Python.h:23:12: \u001b[0m\u001b[0;1;31mfatal error: \u001b[0m\u001b[1m'stdlib.h' file not found\u001b[0m\n",
+      "#  include <stdlib.h>\n",
+      "\u001b[0;1;32m           ^~~~~~~~~~\n",
+      "\u001b[0m1 error generated.\n",
+      "ninja: build stopped: subcommand failed.\n",
       "\n",
       "System:\n",
-      "    python: 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]\n",
-      "executable: /Users/ogrisel/miniforge3/envs/dev/bin/python\n",
-      "   machine: macOS-15.2-arm64-arm-64bit\n",
+      "    python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:13:44) [Clang 16.0.6 ]\n",
+      "executable: /Users/shrutinath/micromamba/envs/scikit-learn/bin/python\n",
+      "   machine: macOS-14.3-arm64-arm-64bit\n",
       "\n",
       "Python dependencies:\n",
       "      sklearn: 1.7.dev0\n",
-      "          pip: 25.0\n",
+      "          pip: 24.0\n",
       "   setuptools: 75.8.0\n",
-      "        numpy: 2.1.3\n",
-      "        scipy: 1.15.1\n",
-      "       Cython: 3.0.11\n",
-      "       pandas: 2.2.3\n",
-      "   matplotlib: 3.10.0\n",
+      "        numpy: 2.0.0\n",
+      "        scipy: 1.14.0\n",
+      "       Cython: 3.0.10\n",
+      "       pandas: 2.2.2\n",
+      "   matplotlib: 3.9.0\n",
       "       joblib: 1.4.2\n",
       "threadpoolctl: 3.5.0\n",
       "\n",
@@ -53,8 +63,8 @@
       "   internal_api: openblas\n",
       "    num_threads: 8\n",
       "         prefix: libopenblas\n",
-      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libopenblas.0.dylib\n",
-      "        version: 0.3.28\n",
+      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libopenblas.0.dylib\n",
+      "        version: 0.3.27\n",
       "threading_layer: openmp\n",
       "   architecture: VORTEX\n",
       "\n",
@@ -62,7 +72,7 @@
       "   internal_api: openmp\n",
       "    num_threads: 8\n",
       "         prefix: libomp\n",
-      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libomp.dylib\n",
+      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libomp.dylib\n",
       "        version: None\n"
      ]
     }
@@ -89,6 +99,9 @@
     "from sklearn.exceptions import ConvergenceWarning\n",
     "import threadpoolctl\n",
     "\n",
+    "\n",
+    "import sys\n",
+    "sys.path.insert(1,\"../src/\")\n",
     "from sample_weight_audit import check_weighted_repeated_estimator_fit_equivalence\n",
     "from sample_weight_audit.exceptions import UnexpectedDeterministicPredictions\n",
     "from sample_weight_audit.sklearn_stochastic_params import STOCHASTIC_FIT_PARAMS\n",
@@ -132,30 +145,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 10.22it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 20.14it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostClassifier: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ AdaBoostClassifier: (p_value: 0.000\n",
       "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
-      "                                                  max_features=0.5))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 46.02it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ AdaBoostRegressor: (min_p_value: 0.071, mean_p_value=0.679)\n",
+      "                                                  max_features=0.5))\n",
+      "❌ AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
+      "                                                  max_features=0.5)) error with: index 95 is out of bounds for axis 0 with size 95\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -166,14 +167,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 30.82it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 70.83it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingClassifier: (min_p_value: 0.000, mean_p_value=0.259)\n",
+      "❌ BaggingClassifier: (p_value: 0.000\n",
       "Evaluating BaggingRegressor()\n"
      ]
     },
@@ -181,20 +182,34 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 43.01it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 45.27it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingRegressor: (min_p_value: 0.000, mean_p_value=0.212)\n",
+      "❌ BaggingRegressor: (p_value: 0.000\n",
       "✅ BayesianRidge() passed the deterministic check\n",
       "✅ BernoulliNB() passed the deterministic check\n",
       "⚠ BernoulliRBM does not support sample_weight\n",
       "⚠ Binarizer does not support sample_weight\n",
       "⚠ Birch does not support sample_weight\n",
-      "⚠ BisectingKMeans skipped: missing proper handling of clustering estimators\n",
+      "Evaluating BisectingKMeans()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 431.12it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ BisectingKMeans() error with: cannot reshape array of size 720 into shape (30,30)\n",
       "⚠ CCA does not support sample_weight\n",
       "✅ CalibratedClassifierCV() passed the deterministic check\n",
       "✅ CategoricalNB() passed the deterministic check\n",
@@ -209,14 +224,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 788.17it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1047.45it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeClassifier: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ DecisionTreeClassifier: (p_value: 0.000\n",
       "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
      ]
     },
@@ -224,14 +239,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 842.20it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1114.62it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DecisionTreeRegressor: (min_p_value: 0.035, mean_p_value=0.713)\n",
+      "❌ DecisionTreeRegressor: (p_value: 0.000\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -241,14 +256,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1804.39it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 2193.29it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DummyClassifier: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "✅ DummyClassifier: (p_value: 0.808\n",
       "✅ DummyRegressor() passed the deterministic check\n",
       "Evaluating ElasticNet(selection='random')\n"
      ]
@@ -257,14 +272,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 254.85it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1069.70it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNet: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ ElasticNet: (p_value: 0.000\n",
       "Evaluating ElasticNetCV(selection='random')\n"
      ]
     },
@@ -272,14 +287,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 30.92it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 56.15it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNetCV: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ ElasticNetCV: (p_value: 0.000\n",
       "Evaluating ExtraTreeClassifier()\n"
      ]
     },
@@ -287,14 +302,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 698.60it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1142.90it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeClassifier: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "✅ ExtraTreeClassifier: (p_value: 0.135\n",
       "Evaluating ExtraTreeRegressor()\n"
      ]
     },
@@ -302,14 +317,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 816.50it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1137.61it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreeRegressor: (min_p_value: 0.035, mean_p_value=0.719)\n",
+      "❌ ExtraTreeRegressor: (p_value: 0.000\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -317,29 +332,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:03<00:00,  8.91it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 15.50it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreesClassifier: (min_p_value: 1.000, mean_p_value=1.000)\n",
-      "Evaluating ExtraTreesRegressor()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 11.33it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ ExtraTreesRegressor: (min_p_value: 0.003, mean_p_value=0.536)\n",
+      "❌ ExtraTreesClassifier: (p_value: 0.000\n",
+      "Evaluating ExtraTreesRegressor()\n",
+      "❌ ExtraTreesRegressor() error with: index 97 is out of bounds for axis 0 with size 94\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -360,14 +362,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:07<00:00,  4.05it/s]\n"
+      "100%|██████████| 30/30 [00:04<00:00,  6.52it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingClassifier: (min_p_value: 0.135, mean_p_value=0.752)\n",
+      "❌ GradientBoostingClassifier: (p_value: 0.000\n",
       "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -375,14 +377,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 23.81it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 31.43it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingRegressor: (min_p_value: 0.239, mean_p_value=0.930)\n",
+      "❌ GradientBoostingRegressor: (p_value: 0.000\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -392,14 +394,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:03<00:00,  9.73it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 19.50it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ HistGradientBoostingClassifier: (min_p_value: 0.000, mean_p_value=0.043)\n",
+      "❌ HistGradientBoostingClassifier: (p_value: 0.000\n",
       "Evaluating HistGradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -407,21 +409,49 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 30.85it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 46.25it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ HistGradientBoostingRegressor: (min_p_value: 0.000, mean_p_value=0.009)\n",
+      "❌ HistGradientBoostingRegressor: (p_value: 0.000\n",
       "❌ HuberRegressor() failed the deterministic check\n",
       "⚠ IncrementalPCA does not support sample_weight\n",
       "⚠ Isomap does not support sample_weight\n",
       "❌ IsotonicRegression() failed the deterministic check\n",
-      "Evaluating KBinsDiscretizer(encode='ordinal', subsample=50)\n",
-      "❌ KBinsDiscretizer(encode='ordinal', subsample=50) error with: sample_weight.shape == (100,), expected (50,)!\n",
-      "⚠ KMeans skipped: missing proper handling of clustering estimators\n",
+      "Evaluating KBinsDiscretizer(encode='ordinal', quantile_method='averaged_inverted_cdf',\n",
+      "                 subsample=50)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 639.17it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ KBinsDiscretizer: (p_value: 0.000\n",
+      "Evaluating KMeans()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 30/30 [00:00<00:00, 576.92it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ KMeans() error with: cannot reshape array of size 720 into shape (30,30)\n",
       "⚠ KNNImputer does not support sample_weight\n",
       "⚠ KNeighborsClassifier does not support sample_weight\n",
       "⚠ KNeighborsRegressor does not support sample_weight\n",
@@ -442,14 +472,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 929.12it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1094.05it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Lasso: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ Lasso: (p_value: 0.000\n",
       "Evaluating LassoCV(selection='random')\n"
      ]
     },
@@ -457,14 +487,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 42.37it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 48.41it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ LassoCV: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ LassoCV: (p_value: 0.000\n",
       "⚠ LassoLars does not support sample_weight\n",
       "⚠ LassoLarsCV does not support sample_weight\n",
       "⚠ LassoLarsIC does not support sample_weight\n",
@@ -478,14 +508,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 48.70it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 166.35it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LinearSVC: (min_p_value: 0.000, mean_p_value=0.015)\n",
+      "❌ LinearSVC: (p_value: 0.000\n",
       "Evaluating LinearSVR(dual=True)\n"
      ]
     },
@@ -493,14 +523,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 260.26it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 694.99it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LinearSVR: (min_p_value: 0.000, mean_p_value=0.051)\n",
+      "❌ LinearSVR: (p_value: 0.000\n",
       "⚠ LocallyLinearEmbedding does not support sample_weight\n",
       "Evaluating LogisticRegression(dual=True, max_iter=10000, solver='liblinear')\n"
      ]
@@ -509,14 +539,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 165.09it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 360.66it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ LogisticRegression: (min_p_value: 0.000, mean_p_value=0.144)\n",
+      "❌ LogisticRegression: (p_value: 0.000\n",
       "Skipping LogisticRegressionCV\n",
       "Evaluating MLPClassifier()\n"
      ]
@@ -525,14 +555,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 10.65it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 15.94it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ MLPClassifier: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ MLPClassifier: (p_value: 0.000\n",
       "Evaluating MLPRegressor()\n"
      ]
     },
@@ -540,19 +570,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 13.12it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 19.31it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ MLPRegressor: (min_p_value: 1.000, mean_p_value=1.000)\n",
+      "❌ MLPRegressor: (p_value: 0.000\n",
       "⚠ MaxAbsScaler does not support sample_weight\n",
       "⚠ MeanShift does not support sample_weight\n",
       "⚠ MinMaxScaler does not support sample_weight\n",
       "⚠ MiniBatchDictionaryLearning does not support sample_weight\n",
-      "⚠ MiniBatchKMeans skipped: missing proper handling of clustering estimators\n",
+      "Evaluating MiniBatchKMeans(reassignment_ratio=0.9)\n",
+      "❌ MiniBatchKMeans(reassignment_ratio=0.9) error with: index 90 is out of bounds for axis 0 with size 81\n",
       "⚠ MiniBatchNMF does not support sample_weight\n",
       "⚠ MiniBatchSparsePCA does not support sample_weight\n",
       "⚠ MissingIndicator does not support sample_weight\n",
@@ -575,14 +606,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 251.54it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 364.04it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ NuSVC: (min_p_value: 0.000, mean_p_value=0.029)\n",
+      "❌ NuSVC: (p_value: 0.000\n",
       "❌ NuSVR() failed the deterministic check\n",
       "⚠ Nystroem does not support sample_weight\n",
       "⚠ OPTICS does not support sample_weight\n",
@@ -607,14 +638,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 398.95it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 588.11it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ Perceptron: (min_p_value: 0.000, mean_p_value=0.010)\n",
+      "❌ Perceptron: (p_value: 0.000\n",
       "✅ PoissonRegressor() passed the deterministic check\n",
       "⚠ PolynomialCountSketch does not support sample_weight\n",
       "⚠ PolynomialFeatures does not support sample_weight\n",
@@ -622,20 +653,7 @@
       "⚠ QuadraticDiscriminantAnalysis does not support sample_weight\n",
       "✅ QuantileRegressor() passed the deterministic check\n",
       "⚠ QuantileTransformer does not support sample_weight\n",
-      "Evaluating RANSACRegressor()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 40%|████      | 12/30 [00:00<00:00, 25.97it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Evaluating RANSACRegressor()\n",
       "❌ RANSACRegressor() error with: Weights sum to zero, can't be normalized\n",
       "⚠ RBFSampler does not support sample_weight\n",
       "⚠ RFE does not support sample_weight\n",
@@ -650,14 +668,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:03<00:00,  7.57it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 11.95it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomForestClassifier: (min_p_value: 0.000, mean_p_value=0.213)\n",
+      "❌ RandomForestClassifier: (p_value: 0.000\n",
       "Evaluating RandomForestRegressor(max_features=0.5)\n"
      ]
     },
@@ -665,14 +683,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:03<00:00,  8.52it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 12.88it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RandomForestRegressor: (min_p_value: 0.000, mean_p_value=0.139)\n",
+      "❌ RandomForestRegressor: (p_value: 0.000\n",
       "Evaluating RandomTreesEmbedding(n_estimators=10)\n"
      ]
     },
@@ -680,14 +698,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 72.42it/s]\n"
+      "  0%|          | 0/30 [00:00<?, ?it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ RandomTreesEmbedding: (min_p_value: 0.135, mean_p_value=0.631)\n",
+      "❌ RandomTreesEmbedding(n_estimators=10) error with: X has 124 features, but GaussianRandomProjection is expecting 150 features as input.\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(solver='sag')\n"
      ]
@@ -696,14 +714,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 144.18it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 203.85it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ Ridge: (min_p_value: 0.000, mean_p_value=0.000)\n",
+      "❌ Ridge: (p_value: 0.000\n",
       "✅ RidgeCV() passed the deterministic check\n",
       "Evaluating RidgeClassifier(solver='saga')\n"
      ]
@@ -712,14 +730,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 44.67it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 68.45it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RidgeClassifier: (min_p_value: 0.000, mean_p_value=0.000)\n",
+      "❌ RidgeClassifier: (p_value: 0.000\n",
       "✅ RidgeClassifierCV() passed the deterministic check\n",
       "⚠ RobustScaler does not support sample_weight\n",
       "Evaluating SGDClassifier()\n"
@@ -729,14 +747,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 307.60it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 545.51it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ SGDClassifier: (min_p_value: 0.000, mean_p_value=0.000)\n",
+      "❌ SGDClassifier: (p_value: 0.000\n",
       "Evaluating SGDRegressor()\n"
      ]
     },
@@ -744,29 +762,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 696.67it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 389.04it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ SGDRegressor: (min_p_value: 0.000, mean_p_value=0.000)\n",
-      "Evaluating SVC(probability=True)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 298.07it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ SVC: (min_p_value: 0.000, mean_p_value=0.001)\n",
+      "❌ SGDRegressor: (p_value: 0.000\n",
+      "Evaluating SVC(probability=True)\n",
+      "❌ SVC(probability=True) error with: index 84 is out of bounds for axis 0 with size 82\n",
       "❌ SVR() failed the deterministic check\n",
       "⚠ SelectFdr does not support sample_weight\n",
       "⚠ SelectFpr does not support sample_weight\n",
@@ -797,13 +802,6 @@
       "⚠ VarianceThreshold does not support sample_weight\n",
       "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
       "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
      ]
     }
    ],
@@ -844,10 +842,6 @@
     "            deterministic_test_results.append((est, e))\n",
     "        continue\n",
     "\n",
-    "    # XXX: how to handle stochastic clustering estimators?\n",
-    "    if is_clusterer(est) and not hasattr(est, \"transform\"):\n",
-    "        print(f\"⚠ {est_name} skipped: missing proper handling of clustering estimators\")\n",
-    "        continue\n",
     "\n",
     "    print(f\"Evaluating {est}\")\n",
     "    try:\n",
@@ -858,8 +852,7 @@
     "        )\n",
     "        pass_or_fail = \"✅\" if result.min_p_value > 0.05 else \"❌\"\n",
     "        print(\n",
-    "            f\"{pass_or_fail} {est_name}: (min_p_value: {result.min_p_value:.3f}, \"\n",
-    "            f\"mean_p_value={result.mean_p_value:.3f})\"\n",
+    "            f\"{pass_or_fail} {est_name}: (p_value: {result.min_p_value:.3f}\"\n",
     "        )\n",
     "        statistical_test_results.append(result)\n",
     "    except UnexpectedDeterministicPredictions:\n",
@@ -884,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -893,9 +886,9 @@
      "text": [
       "✅ 19 passed the deterministic test\n",
       "❌ 4 failed the deterministic test\n",
-      "✅ 15 passed the statistical test\n",
-      "❌ 19 failed the statistical test\n",
-      "❌ 2 other errors\n",
+      "✅ 2 passed the statistical test\n",
+      "❌ 29 failed the statistical test\n",
+      "❌ 8 other errors\n",
       "⚠ 112 estimators lack sample_weight support\n"
      ]
     }
@@ -934,7 +927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -965,208 +958,190 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>HistGradientBoostingRegressor</td>\n",
+       "      <th>30</th>\n",
+       "      <td>SGDRegressor</td>\n",
        "      <td>1.691123e-17</td>\n",
-       "      <td>8.635796e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31</th>\n",
-       "      <td>SGDClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.087025e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>Perceptron</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>9.608038e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>NuSVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>2.930086e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>LogisticRegression</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.441737e-01</td>\n",
+       "      <td>2.824069e-11</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
-       "      <td>LinearSVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.455970e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>32</th>\n",
-       "      <td>SGDRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>7.891067e-07</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>HistGradientBoostingClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>4.349046e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>33</th>\n",
-       "      <td>SVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>1.182655e-03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
-       "      <td>1.014674e-15</td>\n",
-       "      <td>1.387822e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>BaggingRegressor</td>\n",
-       "      <td>8.246510e-12</td>\n",
-       "      <td>2.121099e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>RandomForestClassifier</td>\n",
-       "      <td>8.466416e-10</td>\n",
-       "      <td>2.132368e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaggingClassifier</td>\n",
-       "      <td>6.531236e-09</td>\n",
-       "      <td>2.587033e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>RidgeClassifier</td>\n",
-       "      <td>4.326944e-08</td>\n",
-       "      <td>1.466088e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>Ridge</td>\n",
-       "      <td>1.275006e-06</td>\n",
-       "      <td>3.041802e-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
        "      <td>LinearSVR</td>\n",
-       "      <td>5.795482e-06</td>\n",
-       "      <td>5.087924e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>2.530062e-03</td>\n",
-       "      <td>5.363065e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>3.458008e-02</td>\n",
-       "      <td>7.185169e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>DecisionTreeRegressor</td>\n",
-       "      <td>3.458008e-02</td>\n",
-       "      <td>7.126373e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>AdaBoostRegressor</td>\n",
-       "      <td>7.088799e-02</td>\n",
-       "      <td>6.792121e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>GradientBoostingClassifier</td>\n",
-       "      <td>1.350035e-01</td>\n",
-       "      <td>7.524487e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>RandomTreesEmbedding</td>\n",
-       "      <td>1.350035e-01</td>\n",
-       "      <td>6.310016e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>2.390730e-01</td>\n",
-       "      <td>9.301572e-01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>ExtraTreeClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>MLPClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>ElasticNetCV</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.691123e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>18</th>\n",
-       "      <td>LassoCV</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>LinearSVC</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.822140e-11</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>17</th>\n",
+       "      <td>LassoCV</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>9.778018e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
        "      <td>Lasso</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.691123e-17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>DummyClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>29</th>\n",
+       "      <td>SGDClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>4.334224e-04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>ElasticNet</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <th>14</th>\n",
+       "      <td>HistGradientBoostingRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.110373e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>HistGradientBoostingClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.020833e-05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>7.487882e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
+       "      <td>GradientBoostingClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>4.981785e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
        "      <td>ExtraTreesClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.246312e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.098852e-02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>23</th>\n",
-       "      <td>MLPRegressor</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>NuSVC</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.306223e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>ElasticNetCV</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>Perceptron</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>6.154257e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>RandomForestClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.285648e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>2.456810e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingRegressor</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>3.902919e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>1.691123e-17</td>\n",
+       "      <td>9.627595e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>BaggingClassifier</td>\n",
+       "      <td>1.014674e-15</td>\n",
+       "      <td>1.558044e-01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>AdaBoostClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000e+00</td>\n",
+       "      <td>5.787024e-13</td>\n",
+       "      <td>5.635884e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
+       "      <td>9.236091e-11</td>\n",
+       "      <td>6.052421e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>KBinsDiscretizer</td>\n",
+       "      <td>8.466416e-10</td>\n",
+       "      <td>6.026780e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>Ridge</td>\n",
+       "      <td>1.275006e-06</td>\n",
+       "      <td>2.135869e-04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>RidgeClassifier</td>\n",
+       "      <td>1.275006e-06</td>\n",
+       "      <td>2.749358e-04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
+       "      <td>1.275006e-06</td>\n",
+       "      <td>2.394195e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>5.795482e-06</td>\n",
+       "      <td>1.465679e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>ExtraTreeClassifier</td>\n",
+       "      <td>1.350035e-01</td>\n",
+       "      <td>7.806349e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>DummyClassifier</td>\n",
+       "      <td>8.079632e-01</td>\n",
+       "      <td>9.879396e-01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1174,49 +1149,46 @@
       ],
       "text/plain": [
        "                    estimator_name   min_p_value  mean_p_value\n",
-       "16   HistGradientBoostingRegressor  1.691123e-17  8.635796e-03\n",
-       "31                   SGDClassifier  1.691123e-17  1.087025e-04\n",
-       "25                      Perceptron  1.691123e-17  9.608038e-03\n",
-       "24                           NuSVC  1.691123e-17  2.930086e-02\n",
-       "21              LogisticRegression  1.691123e-17  1.441737e-01\n",
-       "19                       LinearSVC  1.691123e-17  1.455970e-02\n",
-       "32                    SGDRegressor  1.691123e-17  7.891067e-07\n",
-       "15  HistGradientBoostingClassifier  1.691123e-17  4.349046e-02\n",
-       "33                             SVC  1.691123e-17  1.182655e-03\n",
-       "27           RandomForestRegressor  1.014674e-15  1.387822e-01\n",
-       "3                 BaggingRegressor  8.246510e-12  2.121099e-01\n",
-       "26          RandomForestClassifier  8.466416e-10  2.132368e-01\n",
-       "2                BaggingClassifier  6.531236e-09  2.587033e-01\n",
-       "30                 RidgeClassifier  4.326944e-08  1.466088e-04\n",
-       "29                           Ridge  1.275006e-06  3.041802e-04\n",
-       "20                       LinearSVR  5.795482e-06  5.087924e-02\n",
-       "12             ExtraTreesRegressor  2.530062e-03  5.363065e-01\n",
-       "10              ExtraTreeRegressor  3.458008e-02  7.185169e-01\n",
-       "5            DecisionTreeRegressor  3.458008e-02  7.126373e-01\n",
-       "1                AdaBoostRegressor  7.088799e-02  6.792121e-01\n",
-       "13      GradientBoostingClassifier  1.350035e-01  7.524487e-01\n",
-       "28            RandomTreesEmbedding  1.350035e-01  6.310016e-01\n",
-       "14       GradientBoostingRegressor  2.390730e-01  9.301572e-01\n",
-       "9              ExtraTreeClassifier  1.000000e+00  1.000000e+00\n",
-       "4           DecisionTreeClassifier  1.000000e+00  1.000000e+00\n",
-       "22                   MLPClassifier  1.000000e+00  1.000000e+00\n",
-       "8                     ElasticNetCV  1.000000e+00  1.000000e+00\n",
-       "18                         LassoCV  1.000000e+00  1.000000e+00\n",
-       "17                           Lasso  1.000000e+00  1.000000e+00\n",
-       "6                  DummyClassifier  1.000000e+00  1.000000e+00\n",
-       "7                       ElasticNet  1.000000e+00  1.000000e+00\n",
-       "11            ExtraTreesClassifier  1.000000e+00  1.000000e+00\n",
-       "23                    MLPRegressor  1.000000e+00  1.000000e+00\n",
-       "0               AdaBoostClassifier  1.000000e+00  1.000000e+00"
+       "30                    SGDRegressor  1.691123e-17  2.824069e-11\n",
+       "19                       LinearSVR  1.691123e-17  1.691123e-17\n",
+       "18                       LinearSVC  1.691123e-17  2.822140e-11\n",
+       "17                         LassoCV  1.691123e-17  9.778018e-06\n",
+       "16                           Lasso  1.691123e-17  1.691123e-17\n",
+       "29                   SGDClassifier  1.691123e-17  4.334224e-04\n",
+       "14   HistGradientBoostingRegressor  1.691123e-17  2.110373e-02\n",
+       "13  HistGradientBoostingClassifier  1.691123e-17  1.020833e-05\n",
+       "12       GradientBoostingRegressor  1.691123e-17  7.487882e-02\n",
+       "11      GradientBoostingClassifier  1.691123e-17  4.981785e-03\n",
+       "10            ExtraTreesClassifier  1.691123e-17  1.246312e-01\n",
+       "22                    MLPRegressor  1.691123e-17  2.098852e-02\n",
+       "23                           NuSVC  1.691123e-17  2.306223e-03\n",
+       "7                     ElasticNetCV  1.691123e-17  1.691123e-17\n",
+       "6                       ElasticNet  1.691123e-17  1.691123e-17\n",
+       "24                      Perceptron  1.691123e-17  6.154257e-03\n",
+       "25          RandomForestClassifier  1.691123e-17  1.285648e-02\n",
+       "26           RandomForestRegressor  1.691123e-17  2.456810e-02\n",
+       "2                 BaggingRegressor  1.691123e-17  3.902919e-02\n",
+       "20              LogisticRegression  1.691123e-17  1.691123e-17\n",
+       "21                   MLPClassifier  1.691123e-17  9.627595e-02\n",
+       "1                BaggingClassifier  1.014674e-15  1.558044e-01\n",
+       "0               AdaBoostClassifier  5.787024e-13  5.635884e-02\n",
+       "3           DecisionTreeClassifier  9.236091e-11  6.052421e-01\n",
+       "15                KBinsDiscretizer  8.466416e-10  6.026780e-01\n",
+       "27                           Ridge  1.275006e-06  2.135869e-04\n",
+       "28                 RidgeClassifier  1.275006e-06  2.749358e-04\n",
+       "9               ExtraTreeRegressor  1.275006e-06  2.394195e-01\n",
+       "4            DecisionTreeRegressor  5.795482e-06  1.465679e-01\n",
+       "8              ExtraTreeClassifier  1.350035e-01  7.806349e-01\n",
+       "5                  DummyClassifier  8.079632e-01  9.879396e-01"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "results_df.sort_values(\"min_p_value\")[[\"estimator_name\", \"min_p_value\", \"mean_p_value\"]]"
+    "results_df.sort_values(\"min_p_value\")[[\"estimator_name\", \"min_p_value\",\"mean_p_value\"]]"
    ]
   },
   {
@@ -1228,7 +1200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1428,7 +1400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1539,7 +1511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1683,7 +1655,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -127,25 +127,25 @@
      "output_type": "stream",
      "text": [
       "⚠ ARDRegression does not support sample_weight\n",
-      "Evaluating AdaBoostClassifier(estimator=DecisionTreeClassifier(class_weight='balanced',\n",
-      "                                                    max_depth=1,\n",
-      "                                                    max_features=0.5))\n"
+      "Evaluating AdaBoostClassifier(estimator=DecisionTreeClassifier(max_features=0.5,\n",
+      "                                                    min_samples_split=0.3))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 63%|██████▎   | 19/30 [00:00<00:00, 23.77it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 18.97it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ AdaBoostClassifier(estimator=DecisionTreeClassifier(class_weight='balanced',\n",
-      "                                                    max_depth=1,\n",
-      "                                                    max_features=0.5)) error with: BaseClassifier in AdaBoostClassifier ensemble is worse than random, ensemble can not be fit.\n",
+      "⚠ AdaBoostClassifier with different random states led to the same predictions\n",
+      "✅ AdaBoostClassifier(estimator=DecisionTreeClassifier(max_features=0.5,\n",
+      "                                                    min_samples_split=0.3),\n",
+      "                   random_state=0) passed the deterministic check\n",
       "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
       "                                                  max_features=0.5))\n"
      ]
@@ -154,14 +154,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 70.41it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 131.20it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ AdaBoostRegressor: (p_value: 0.035\n",
+      "✅ AdaBoostRegressor: (p_value: 0.135\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -172,7 +172,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 66.60it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 71.34it/s]\n"
      ]
     },
     {
@@ -187,7 +187,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 73.64it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 72.72it/s]\n"
      ]
     },
     {
@@ -207,14 +207,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 398.98it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 385.46it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BisectingKMeans: (p_value: 0.007\n",
+      "❌ BisectingKMeans: (p_value: 0.016\n",
       "⚠ CCA does not support sample_weight\n",
       "✅ CalibratedClassifierCV() passed the deterministic check\n",
       "✅ CategoricalNB() passed the deterministic check\n",
@@ -222,21 +222,21 @@
       "⚠ ColumnTransformer does not support sample_weight\n",
       "✅ ComplementNB() passed the deterministic check\n",
       "✅ DBSCAN() passed the deterministic check\n",
-      "Evaluating DecisionTreeClassifier(class_weight='balanced', max_features=0.5)\n"
+      "Evaluating DecisionTreeClassifier(max_features=0.5, min_samples_split=0.3)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 893.71it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1123.21it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeClassifier: (p_value: 0.958\n",
+      "❌ DecisionTreeClassifier: (p_value: 0.000\n",
       "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
      ]
     },
@@ -244,14 +244,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1131.64it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1084.01it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DecisionTreeRegressor: (p_value: 0.001\n",
+      "❌ DecisionTreeRegressor: (p_value: 0.007\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -261,7 +261,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 2156.57it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 2144.55it/s]\n"
      ]
     },
     {
@@ -277,7 +277,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1121.36it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1005.09it/s]\n"
      ]
     },
     {
@@ -292,7 +292,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 56.62it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 56.39it/s]\n"
      ]
     },
     {
@@ -307,7 +307,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1129.65it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1132.50it/s]\n"
      ]
     },
     {
@@ -322,14 +322,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1137.00it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1115.41it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeRegressor: (p_value: 0.071\n",
+      "✅ ExtraTreeRegressor: (p_value: 0.239\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -337,7 +337,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 14.66it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 15.79it/s]\n"
      ]
     },
     {
@@ -352,14 +352,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 16.37it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 15.75it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreesRegressor: (p_value: 0.000\n",
+      "✅ ExtraTreesRegressor: (p_value: 0.135\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -380,7 +380,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:04<00:00,  6.43it/s]\n"
+      "100%|██████████| 30/30 [00:04<00:00,  6.44it/s]\n"
      ]
     },
     {
@@ -395,14 +395,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 30.10it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 30.72it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingRegressor: (p_value: 0.135\n",
+      "✅ GradientBoostingRegressor: (p_value: 0.393\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -412,7 +412,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 16.97it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 17.31it/s]\n"
      ]
     },
     {
@@ -427,7 +427,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 45.74it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 49.24it/s]\n"
      ]
     },
     {
@@ -447,7 +447,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 376.60it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 417.64it/s]\n"
      ]
     },
     {
@@ -462,14 +462,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 524.90it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 559.23it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ KMeans: (p_value: 0.016\n",
+      "✅ KMeans: (p_value: 0.071\n",
       "⚠ KNNImputer does not support sample_weight\n",
       "⚠ KNeighborsClassifier does not support sample_weight\n",
       "⚠ KNeighborsRegressor does not support sample_weight\n",
@@ -490,7 +490,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 994.14it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1120.87it/s]\n"
      ]
     },
     {
@@ -505,7 +505,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 54.61it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 54.53it/s]\n"
      ]
     },
     {
@@ -526,7 +526,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 126.74it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 273.98it/s]\n"
      ]
     },
     {
@@ -541,7 +541,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 322.23it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 1464.41it/s]\n"
      ]
     },
     {
@@ -557,7 +557,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 339.74it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 239.30it/s]\n"
      ]
     },
     {
@@ -573,7 +573,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 17.01it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 18.34it/s]\n"
      ]
     },
     {
@@ -588,7 +588,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 18.71it/s]\n"
+      "100%|██████████| 30/30 [00:01<00:00, 19.02it/s]\n"
      ]
     },
     {
@@ -607,14 +607,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 304.74it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 315.66it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ MiniBatchKMeans: (p_value: 0.007\n",
+      "❌ MiniBatchKMeans: (p_value: 0.003\n",
       "⚠ MiniBatchNMF does not support sample_weight\n",
       "⚠ MiniBatchSparsePCA does not support sample_weight\n",
       "⚠ MissingIndicator does not support sample_weight\n",
@@ -637,7 +637,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 323.12it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 291.43it/s]\n"
      ]
     },
     {
@@ -669,7 +669,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 561.88it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 581.79it/s]\n"
      ]
     },
     {
@@ -684,20 +684,7 @@
       "⚠ QuadraticDiscriminantAnalysis does not support sample_weight\n",
       "✅ QuantileRegressor() passed the deterministic check\n",
       "⚠ QuantileTransformer does not support sample_weight\n",
-      "Evaluating RANSACRegressor()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 47%|████▋     | 14/30 [00:00<00:00, 41.78it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Evaluating RANSACRegressor()\n",
       "❌ RANSACRegressor() error with: Weights sum to zero, can't be normalized\n",
       "⚠ RBFSampler does not support sample_weight\n",
       "⚠ RFE does not support sample_weight\n",
@@ -712,7 +699,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 11.49it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 11.77it/s]\n"
      ]
     },
     {
@@ -727,7 +714,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 12.35it/s]\n"
+      "100%|██████████| 30/30 [00:02<00:00, 12.83it/s]\n"
      ]
     },
     {
@@ -742,14 +729,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 95.13it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 94.92it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ RandomTreesEmbedding: (p_value: 0.071\n",
+      "✅ RandomTreesEmbedding: (p_value: 0.135\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(solver='sag')\n"
      ]
@@ -758,7 +745,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 200.56it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 200.28it/s]\n"
      ]
     },
     {
@@ -767,21 +754,8 @@
      "text": [
       "❌ Ridge: (p_value: 0.000\n",
       "✅ RidgeCV() passed the deterministic check\n",
-      "Evaluating RidgeClassifier(solver='saga')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 17%|█▋        | 5/30 [00:00<00:00, 62.34it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ RidgeClassifier(solver='saga') error with: Floating-point under-/overflow occurred at epoch #989. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Evaluating RidgeClassifier(solver='saga')\n",
+      "❌ RidgeClassifier(solver='saga') error with: Floating-point under-/overflow occurred at epoch #689. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "✅ RidgeClassifierCV() passed the deterministic check\n",
       "⚠ RobustScaler does not support sample_weight\n",
       "Evaluating SGDClassifier()\n"
@@ -791,7 +765,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 525.43it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 516.21it/s]\n"
      ]
     },
     {
@@ -806,7 +780,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 826.47it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 911.61it/s]\n"
      ]
     },
     {
@@ -821,7 +795,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 198.29it/s]\n"
+      "100%|██████████| 30/30 [00:00<00:00, 392.44it/s]"
      ]
     },
     {
@@ -859,6 +833,13 @@
       "⚠ VarianceThreshold does not support sample_weight\n",
       "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
       "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],

--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -30,20 +30,20 @@
      "text": [
       "\n",
       "System:\n",
-      "    python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:13:44) [Clang 16.0.6 ]\n",
-      "executable: /Users/shrutinath/micromamba/envs/scikit-learn/bin/python\n",
-      "   machine: macOS-14.3-arm64-arm-64bit\n",
+      "    python: 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]\n",
+      "executable: /Users/ogrisel/miniforge3/envs/dev/bin/python\n",
+      "   machine: macOS-15.2-arm64-arm-64bit\n",
       "\n",
       "Python dependencies:\n",
       "      sklearn: 1.7.dev0\n",
-      "          pip: 24.0\n",
+      "          pip: 25.0\n",
       "   setuptools: 75.8.0\n",
-      "        numpy: 2.0.0\n",
-      "        scipy: 1.14.0\n",
-      "       Cython: 3.0.10\n",
-      "       pandas: 2.2.2\n",
-      "   matplotlib: 3.9.0\n",
-      "       joblib: 1.4.2\n",
+      "        numpy: 2.1.3\n",
+      "        scipy: 1.15.1\n",
+      "       Cython: 3.0.11\n",
+      "       pandas: 2.2.3\n",
+      "   matplotlib: 3.10.0\n",
+      "       joblib: 1.5.dev0\n",
       "threadpoolctl: 3.5.0\n",
       "\n",
       "Built with OpenMP: True\n",
@@ -53,8 +53,8 @@
       "   internal_api: openblas\n",
       "    num_threads: 8\n",
       "         prefix: libopenblas\n",
-      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libopenblas.0.dylib\n",
-      "        version: 0.3.27\n",
+      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libopenblas.0.dylib\n",
+      "        version: 0.3.28\n",
       "threading_layer: openmp\n",
       "   architecture: VORTEX\n",
       "\n",
@@ -62,7 +62,7 @@
       "   internal_api: openmp\n",
       "    num_threads: 8\n",
       "         prefix: libomp\n",
-      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libomp.dylib\n",
+      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libomp.dylib\n",
       "        version: None\n"
      ]
     }
@@ -90,8 +90,6 @@
     "import threadpoolctl\n",
     "\n",
     "\n",
-    "import sys\n",
-    "sys.path.insert(1,\"../src/\")\n",
     "from sample_weight_audit import check_weighted_repeated_estimator_fit_equivalence\n",
     "from sample_weight_audit.exceptions import UnexpectedDeterministicPredictions\n",
     "from sample_weight_audit.sklearn_stochastic_params import STOCHASTIC_FIT_PARAMS\n",
@@ -119,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -128,40 +126,37 @@
      "text": [
       "⚠ ARDRegression does not support sample_weight\n",
       "Evaluating AdaBoostClassifier(estimator=DecisionTreeClassifier(max_features=0.5,\n",
-      "                                                    min_samples_split=0.3))\n"
+      "                                                    min_weight_fraction_leaf=0.1))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 18.97it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 14.35it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "⚠ AdaBoostClassifier with different random states led to the same predictions\n",
-      "✅ AdaBoostClassifier(estimator=DecisionTreeClassifier(max_features=0.5,\n",
-      "                                                    min_samples_split=0.3),\n",
-      "                   random_state=0) passed the deterministic check\n",
-      "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_depth=1,\n",
-      "                                                  max_features=0.5))\n"
+      "✅ AdaBoostClassifier: (min p_value: 0.078)\n",
+      "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_features=0.5,\n",
+      "                                                  min_weight_fraction_leaf=0.1))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 131.20it/s]\n"
+      "100%|██████████| 100/100 [00:05<00:00, 18.28it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostRegressor: (p_value: 0.135\n",
+      "✅ AdaBoostRegressor: (min p_value: 0.016)\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -172,14 +167,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 71.34it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 57.63it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingClassifier: (p_value: 0.000\n",
+      "❌ BaggingClassifier: (min p_value: 0.000)\n",
       "Evaluating BaggingRegressor()\n"
      ]
     },
@@ -187,14 +182,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 72.72it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 59.36it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingRegressor: (p_value: 0.000\n",
+      "❌ BaggingRegressor: (min p_value: 0.000)\n",
       "✅ BayesianRidge() passed the deterministic check\n",
       "✅ BernoulliNB() passed the deterministic check\n",
       "⚠ BernoulliRBM does not support sample_weight\n",
@@ -207,14 +202,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 385.46it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 272.56it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BisectingKMeans: (p_value: 0.016\n",
+      "✅ BisectingKMeans: (min p_value: 0.036)\n",
       "⚠ CCA does not support sample_weight\n",
       "✅ CalibratedClassifierCV() passed the deterministic check\n",
       "✅ CategoricalNB() passed the deterministic check\n",
@@ -222,21 +217,21 @@
       "⚠ ColumnTransformer does not support sample_weight\n",
       "✅ ComplementNB() passed the deterministic check\n",
       "✅ DBSCAN() passed the deterministic check\n",
-      "Evaluating DecisionTreeClassifier(max_features=0.5, min_samples_split=0.3)\n"
+      "Evaluating DecisionTreeClassifier(max_features=0.5, min_weight_fraction_leaf=0.1)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1123.21it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 883.00it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DecisionTreeClassifier: (p_value: 0.000\n",
+      "✅ DecisionTreeClassifier: (min p_value: 0.211)\n",
       "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
      ]
     },
@@ -244,14 +239,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1084.01it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 924.94it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ DecisionTreeRegressor: (p_value: 0.007\n",
+      "✅ DecisionTreeRegressor: (min p_value: 0.000)\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -261,14 +256,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 2144.55it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 1897.86it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DummyClassifier: (p_value: 1.000\n",
+      "✅ DummyClassifier: (min p_value: 0.282)\n",
       "✅ DummyRegressor() passed the deterministic check\n",
       "Evaluating ElasticNet(selection='random')\n"
      ]
@@ -277,14 +272,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1005.09it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 662.75it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNet: (p_value: 1.000\n",
+      "✅ ElasticNet: (min p_value: 0.282)\n",
       "Evaluating ElasticNetCV(selection='random')\n"
      ]
     },
@@ -292,14 +287,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 56.39it/s]\n"
+      "100%|██████████| 100/100 [00:02<00:00, 44.54it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNetCV: (p_value: 1.000\n",
+      "✅ ElasticNetCV: (min p_value: 0.024)\n",
       "Evaluating ExtraTreeClassifier()\n"
      ]
     },
@@ -307,14 +302,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1132.50it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 910.40it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeClassifier: (p_value: 1.000\n",
+      "✅ ExtraTreeClassifier: (min p_value: 0.908)\n",
       "Evaluating ExtraTreeRegressor()\n"
      ]
     },
@@ -322,14 +317,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1115.41it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 801.96it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeRegressor: (p_value: 0.239\n",
+      "✅ ExtraTreeRegressor: (min p_value: 0.001)\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -337,513 +332,46 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 15.79it/s]\n"
+      " 56%|█████▌    | 56/100 [00:04<00:03, 12.20it/s]\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ ExtraTreesClassifier: (p_value: 1.000\n",
-      "Evaluating ExtraTreesRegressor()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 15.75it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ ExtraTreesRegressor: (p_value: 0.135\n",
-      "⚠ FactorAnalysis does not support sample_weight\n",
-      "⚠ FastICA does not support sample_weight\n",
-      "⚠ FeatureAgglomeration does not support sample_weight\n",
-      "⚠ FeatureHasher does not support sample_weight\n",
-      "⚠ FeatureUnion does not support sample_weight\n",
-      "⚠ FixedThresholdClassifier does not support sample_weight\n",
-      "⚠ FunctionTransformer does not support sample_weight\n",
-      "✅ GammaRegressor() passed the deterministic check\n",
-      "✅ GaussianNB() passed the deterministic check\n",
-      "⚠ GaussianProcessClassifier does not support sample_weight\n",
-      "⚠ GaussianProcessRegressor does not support sample_weight\n",
-      "⚠ GaussianRandomProjection does not support sample_weight\n",
-      "⚠ GenericUnivariateSelect does not support sample_weight\n",
-      "Evaluating GradientBoostingClassifier(max_features=0.5)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:04<00:00,  6.44it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ GradientBoostingClassifier: (p_value: 0.239\n",
-      "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 30.72it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ GradientBoostingRegressor: (p_value: 0.393\n",
-      "⚠ HDBSCAN does not support sample_weight\n",
-      "⚠ HashingVectorizer does not support sample_weight\n",
-      "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 17.31it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ HistGradientBoostingClassifier: (p_value: 0.000\n",
-      "Evaluating HistGradientBoostingRegressor(max_features=0.5)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 49.24it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ HistGradientBoostingRegressor: (p_value: 0.000\n",
-      "❌ HuberRegressor() failed the deterministic check\n",
-      "⚠ IncrementalPCA does not support sample_weight\n",
-      "⚠ Isomap does not support sample_weight\n",
-      "❌ IsotonicRegression() failed the deterministic check\n",
-      "Evaluating KBinsDiscretizer(encode='ordinal', quantile_method='averaged_inverted_cdf',\n",
-      "                 subsample=50)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 417.64it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ KBinsDiscretizer: (p_value: 0.071\n",
-      "Evaluating KMeans(n_clusters=10)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 559.23it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ KMeans: (p_value: 0.071\n",
-      "⚠ KNNImputer does not support sample_weight\n",
-      "⚠ KNeighborsClassifier does not support sample_weight\n",
-      "⚠ KNeighborsRegressor does not support sample_weight\n",
-      "⚠ KNeighborsTransformer does not support sample_weight\n",
-      "⚠ KernelCenterer does not support sample_weight\n",
-      "⚠ KernelPCA does not support sample_weight\n",
-      "✅ KernelRidge() passed the deterministic check\n",
-      "⚠ LabelBinarizer does not support sample_weight\n",
-      "⚠ LabelEncoder does not support sample_weight\n",
-      "⚠ LabelPropagation does not support sample_weight\n",
-      "⚠ LabelSpreading does not support sample_weight\n",
-      "⚠ Lars does not support sample_weight\n",
-      "⚠ LarsCV does not support sample_weight\n",
-      "Evaluating Lasso(selection='random')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1120.87it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Lasso: (p_value: 1.000\n",
-      "Evaluating LassoCV(selection='random')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 54.53it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ LassoCV: (p_value: 0.000\n",
-      "⚠ LassoLars does not support sample_weight\n",
-      "⚠ LassoLarsCV does not support sample_weight\n",
-      "⚠ LassoLarsIC does not support sample_weight\n",
-      "⚠ LatentDirichletAllocation does not support sample_weight\n",
-      "⚠ LinearDiscriminantAnalysis does not support sample_weight\n",
-      "✅ LinearRegression() passed the deterministic check\n",
-      "Evaluating LinearSVC(dual=True)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 273.98it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ LinearSVC: (p_value: 0.000\n",
-      "Evaluating LinearSVR(dual=True)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 1464.41it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ LinearSVR: (p_value: 0.000\n",
-      "⚠ LocallyLinearEmbedding does not support sample_weight\n",
-      "Evaluating LogisticRegression(dual=True, max_iter=10000, solver='liblinear')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 239.30it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ LogisticRegression: (p_value: 0.000\n",
-      "Skipping LogisticRegressionCV\n",
-      "Evaluating MLPClassifier()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 18.34it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ MLPClassifier: (p_value: 1.000\n",
-      "Evaluating MLPRegressor()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:01<00:00, 19.02it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ MLPRegressor: (p_value: 1.000\n",
-      "⚠ MaxAbsScaler does not support sample_weight\n",
-      "⚠ MeanShift does not support sample_weight\n",
-      "⚠ MinMaxScaler does not support sample_weight\n",
-      "⚠ MiniBatchDictionaryLearning does not support sample_weight\n",
-      "Evaluating MiniBatchKMeans(n_clusters=10, reassignment_ratio=0.9)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 315.66it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ MiniBatchKMeans: (p_value: 0.003\n",
-      "⚠ MiniBatchNMF does not support sample_weight\n",
-      "⚠ MiniBatchSparsePCA does not support sample_weight\n",
-      "⚠ MissingIndicator does not support sample_weight\n",
-      "⚠ MultiLabelBinarizer does not support sample_weight\n",
-      "⚠ MultiOutputClassifier failed to instantiate: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'\n",
-      "⚠ MultiOutputRegressor failed to instantiate: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'\n",
-      "⚠ MultiTaskElasticNet does not support sample_weight\n",
-      "⚠ MultiTaskElasticNetCV does not support sample_weight\n",
-      "⚠ MultiTaskLasso does not support sample_weight\n",
-      "⚠ MultiTaskLassoCV does not support sample_weight\n",
-      "✅ MultinomialNB() passed the deterministic check\n",
-      "⚠ NMF does not support sample_weight\n",
-      "⚠ NearestCentroid does not support sample_weight\n",
-      "⚠ NeighborhoodComponentsAnalysis does not support sample_weight\n",
-      "⚠ Normalizer does not support sample_weight\n",
-      "Evaluating NuSVC(probability=True)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 291.43it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ NuSVC: (p_value: 0.000\n",
-      "❌ NuSVR() failed the deterministic check\n",
-      "⚠ Nystroem does not support sample_weight\n",
-      "⚠ OPTICS does not support sample_weight\n",
-      "⚠ OneHotEncoder does not support sample_weight\n",
-      "⚠ OneVsOneClassifier does not support sample_weight\n",
-      "⚠ OneVsRestClassifier does not support sample_weight\n",
-      "⚠ OrdinalEncoder does not support sample_weight\n",
-      "⚠ OrthogonalMatchingPursuit does not support sample_weight\n",
-      "⚠ OrthogonalMatchingPursuitCV does not support sample_weight\n",
-      "⚠ OutputCodeClassifier does not support sample_weight\n",
-      "⚠ PCA does not support sample_weight\n",
-      "⚠ PLSCanonical does not support sample_weight\n",
-      "⚠ PLSRegression does not support sample_weight\n",
-      "⚠ PLSSVD does not support sample_weight\n",
-      "⚠ PassiveAggressiveClassifier does not support sample_weight\n",
-      "⚠ PassiveAggressiveRegressor does not support sample_weight\n",
-      "⚠ PatchExtractor does not support sample_weight\n",
-      "Evaluating Perceptron()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 581.79it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ Perceptron: (p_value: 0.000\n",
-      "✅ PoissonRegressor() passed the deterministic check\n",
-      "⚠ PolynomialCountSketch does not support sample_weight\n",
-      "⚠ PolynomialFeatures does not support sample_weight\n",
-      "⚠ PowerTransformer does not support sample_weight\n",
-      "⚠ QuadraticDiscriminantAnalysis does not support sample_weight\n",
-      "✅ QuantileRegressor() passed the deterministic check\n",
-      "⚠ QuantileTransformer does not support sample_weight\n",
-      "Evaluating RANSACRegressor()\n",
-      "❌ RANSACRegressor() error with: Weights sum to zero, can't be normalized\n",
-      "⚠ RBFSampler does not support sample_weight\n",
-      "⚠ RFE does not support sample_weight\n",
-      "⚠ RFECV does not support sample_weight\n",
-      "⚠ RadiusNeighborsClassifier does not support sample_weight\n",
-      "⚠ RadiusNeighborsRegressor does not support sample_weight\n",
-      "⚠ RadiusNeighborsTransformer does not support sample_weight\n",
-      "Evaluating RandomForestClassifier()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 11.77it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ RandomForestClassifier: (p_value: 0.000\n",
-      "Evaluating RandomForestRegressor(max_features=0.5)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:02<00:00, 12.83it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ RandomForestRegressor: (p_value: 0.000\n",
-      "Evaluating RandomTreesEmbedding(n_estimators=10)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 94.92it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ RandomTreesEmbedding: (p_value: 0.135\n",
-      "⚠ RegressorChain does not support sample_weight\n",
-      "Evaluating Ridge(solver='sag')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 200.28it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ Ridge: (p_value: 0.000\n",
-      "✅ RidgeCV() passed the deterministic check\n",
-      "Evaluating RidgeClassifier(solver='saga')\n",
-      "❌ RidgeClassifier(solver='saga') error with: Floating-point under-/overflow occurred at epoch #689. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
-      "✅ RidgeClassifierCV() passed the deterministic check\n",
-      "⚠ RobustScaler does not support sample_weight\n",
-      "Evaluating SGDClassifier()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 516.21it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ SGDClassifier: (p_value: 0.000\n",
-      "Evaluating SGDRegressor()\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 911.61it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ SGDRegressor: (p_value: 0.000\n",
-      "Evaluating SVC(probability=True)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 30/30 [00:00<00:00, 392.44it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ SVC: (p_value: 0.000\n",
-      "❌ SVR() failed the deterministic check\n",
-      "⚠ SelectFdr does not support sample_weight\n",
-      "⚠ SelectFpr does not support sample_weight\n",
-      "⚠ SelectFromModel does not support sample_weight\n",
-      "⚠ SelectFwe does not support sample_weight\n",
-      "⚠ SelectKBest does not support sample_weight\n",
-      "⚠ SelectPercentile does not support sample_weight\n",
-      "⚠ SelfTrainingClassifier does not support sample_weight\n",
-      "⚠ SequentialFeatureSelector does not support sample_weight\n",
-      "⚠ SimpleImputer does not support sample_weight\n",
-      "⚠ SkewedChi2Sampler does not support sample_weight\n",
-      "⚠ SparseCoder does not support sample_weight\n",
-      "⚠ SparsePCA does not support sample_weight\n",
-      "⚠ SparseRandomProjection does not support sample_weight\n",
-      "⚠ SpectralClustering does not support sample_weight\n",
-      "✅ SplineTransformer() passed the deterministic check\n",
-      "⚠ StackingClassifier failed to instantiate: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
-      "⚠ StackingRegressor failed to instantiate: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'\n",
-      "✅ StandardScaler() passed the deterministic check\n",
-      "⚠ TSNE does not support sample_weight\n",
-      "⚠ TargetEncoder does not support sample_weight\n",
-      "⚠ TfidfTransformer does not support sample_weight\n",
-      "⚠ TheilSenRegressor does not support sample_weight\n",
-      "⚠ TransformedTargetRegressor does not support sample_weight\n",
-      "⚠ TruncatedSVD does not support sample_weight\n",
-      "⚠ TunedThresholdClassifierCV does not support sample_weight\n",
-      "✅ TweedieRegressor() passed the deterministic check\n",
-      "⚠ VarianceThreshold does not support sample_weight\n",
-      "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
-      "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 47\u001b[0m\n\u001b[1;32m     45\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mEvaluating \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mest\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     46\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 47\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mcheck_weighted_repeated_estimator_fit_equivalence\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     48\u001b[0m \u001b[43m        \u001b[49m\u001b[43mest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     49\u001b[0m \u001b[43m        \u001b[49m\u001b[43mtest_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mkstest\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m     50\u001b[0m \u001b[43m        \u001b[49m\u001b[43mstat_test_dim\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mSTAT_TEST_DIM\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     51\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_stochastic_fits\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mN_STOCHASTIC_FITS\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     52\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrandom_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m     53\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     54\u001b[0m     pass_or_fail \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m✅\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m result\u001b[38;5;241m.\u001b[39mmin_p_value \u001b[38;5;241m>\u001b[39m CONFIDENCE_LEVEL \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m❌\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     55\u001b[0m     \u001b[38;5;28mprint\u001b[39m(\n\u001b[1;32m     56\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mpass_or_fail\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mest_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m: (min p_value: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mresult\u001b[38;5;241m.\u001b[39mmin_p_value\u001b[38;5;132;01m:\u001b[39;00m\u001b[38;5;124m.3f\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m)\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     57\u001b[0m     )\n",
+      "File \u001b[0;32m~/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py:83\u001b[0m, in \u001b[0;36mcheck_weighted_repeated_estimator_fit_equivalence\u001b[0;34m(est, test_name, n_samples_per_cv_group, n_cv_group, n_features, n_classes, max_sample_weight, n_stochastic_fits, stat_test_dim, random_state)\u001b[0m\n\u001b[1;32m     52\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mcheck_weighted_repeated_estimator_fit_equivalence\u001b[39m(\n\u001b[1;32m     53\u001b[0m     est,\n\u001b[1;32m     54\u001b[0m     test_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mkstest\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     62\u001b[0m     random_state\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     63\u001b[0m ):\n\u001b[1;32m     64\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Assess the correct use of weights for estimators with stochastic fits.\u001b[39;00m\n\u001b[1;32m     65\u001b[0m \n\u001b[1;32m     66\u001b[0m \u001b[38;5;124;03m    This function fits an estimator with different random seeds, either with\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     80\u001b[0m \n\u001b[1;32m     81\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 83\u001b[0m     predictions_weighted, predictions_repeated, _ \u001b[38;5;241m=\u001b[39m \u001b[43mmultifit_over_weighted_and_repeated\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     84\u001b[0m \u001b[43m        \u001b[49m\u001b[43mest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     85\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_features\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_features\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     86\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_classes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_classes\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     87\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_stochastic_fits\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_stochastic_fits\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     88\u001b[0m \u001b[43m        \u001b[49m\u001b[43mstat_test_dim\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mstat_test_dim\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     89\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_samples_per_cv_group\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_samples_per_cv_group\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     90\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_cv_group\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_cv_group\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     91\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmax_sample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmax_sample_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     92\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrandom_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrandom_state\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     93\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     94\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m (\n\u001b[1;32m     95\u001b[0m         predictions_weighted\u001b[38;5;241m.\u001b[39mndim \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m3\u001b[39m\n\u001b[1;32m     96\u001b[0m     )  \u001b[38;5;66;03m# (n_stochastic_fits, n_test_data_points, prediction_dim)\u001b[39;00m\n\u001b[1;32m     97\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m predictions_weighted\u001b[38;5;241m.\u001b[39mshape \u001b[38;5;241m==\u001b[39m predictions_repeated\u001b[38;5;241m.\u001b[39mshape\n",
+      "File \u001b[0;32m~/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py:302\u001b[0m, in \u001b[0;36mmultifit_over_weighted_and_repeated\u001b[0;34m(est, n_stochastic_fits, stat_test_dim, n_samples_per_cv_group, n_cv_group, n_features, n_classes, test_pool_size, max_sample_weight, random_state)\u001b[0m\n\u001b[1;32m    297\u001b[0m \u001b[38;5;66;03m# Use different random seeds for the other group of fits to avoid\u001b[39;00m\n\u001b[1;32m    298\u001b[0m \u001b[38;5;66;03m# introducing an unwanted statistical dependency.\u001b[39;00m\n\u001b[1;32m    299\u001b[0m est_repeated \u001b[38;5;241m=\u001b[39m clone(est)\u001b[38;5;241m.\u001b[39mset_params(\n\u001b[1;32m    300\u001b[0m     random_state\u001b[38;5;241m=\u001b[39mseed \u001b[38;5;241m+\u001b[39m n_stochastic_fits, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mextra_params_repeated\n\u001b[1;32m    301\u001b[0m )\n\u001b[0;32m--> 302\u001b[0m est_weighted \u001b[38;5;241m=\u001b[39m \u001b[43mcheck_pipeline_and_fit\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    303\u001b[0m \u001b[43m    \u001b[49m\u001b[43mest_weighted\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    304\u001b[0m \u001b[43m    \u001b[49m\u001b[43mX_train\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    305\u001b[0m \u001b[43m    \u001b[49m\u001b[43my_train\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    306\u001b[0m \u001b[43m    \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msample_weight_train\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    307\u001b[0m \u001b[43m    \u001b[49m\u001b[43mseed\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mseed\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    308\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    309\u001b[0m est_repeated \u001b[38;5;241m=\u001b[39m check_pipeline_and_fit(\n\u001b[1;32m    310\u001b[0m     est_repeated,\n\u001b[1;32m    311\u001b[0m     X_resampled_by_weights,\n\u001b[1;32m    312\u001b[0m     y_resampled_by_weights,\n\u001b[1;32m    313\u001b[0m     seed\u001b[38;5;241m=\u001b[39mseed,\n\u001b[1;32m    314\u001b[0m )\n\u001b[1;32m    316\u001b[0m predictions_weighted \u001b[38;5;241m=\u001b[39m compute_predictions(est_weighted, X_test_diverse_subset)\n",
+      "File \u001b[0;32m~/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py:196\u001b[0m, in \u001b[0;36mcheck_pipeline_and_fit\u001b[0;34m(est, X, y, sample_weight, seed)\u001b[0m\n\u001b[1;32m    189\u001b[0m     est \u001b[38;5;241m=\u001b[39m est\u001b[38;5;241m.\u001b[39mfit(\n\u001b[1;32m    190\u001b[0m         X,\n\u001b[1;32m    191\u001b[0m         y,\n\u001b[1;32m    192\u001b[0m         transformer__sample_weight\u001b[38;5;241m=\u001b[39msample_weight,\n\u001b[1;32m    193\u001b[0m         ridge__sample_weight\u001b[38;5;241m=\u001b[39msample_weight,\n\u001b[1;32m    194\u001b[0m     )\n\u001b[1;32m    195\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 196\u001b[0m     est \u001b[38;5;241m=\u001b[39m \u001b[43mest\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msample_weight\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    197\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m est\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/base.py:1389\u001b[0m, in \u001b[0;36m_fit_context.<locals>.decorator.<locals>.wrapper\u001b[0;34m(estimator, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1382\u001b[0m     estimator\u001b[38;5;241m.\u001b[39m_validate_params()\n\u001b[1;32m   1384\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m config_context(\n\u001b[1;32m   1385\u001b[0m     skip_parameter_validation\u001b[38;5;241m=\u001b[39m(\n\u001b[1;32m   1386\u001b[0m         prefer_skip_nested_validation \u001b[38;5;129;01mor\u001b[39;00m global_skip_validation\n\u001b[1;32m   1387\u001b[0m     )\n\u001b[1;32m   1388\u001b[0m ):\n\u001b[0;32m-> 1389\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfit_method\u001b[49m\u001b[43m(\u001b[49m\u001b[43mestimator\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/ensemble/_forest.py:487\u001b[0m, in \u001b[0;36mBaseForest.fit\u001b[0;34m(self, X, y, sample_weight)\u001b[0m\n\u001b[1;32m    476\u001b[0m trees \u001b[38;5;241m=\u001b[39m [\n\u001b[1;32m    477\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_make_estimator(append\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, random_state\u001b[38;5;241m=\u001b[39mrandom_state)\n\u001b[1;32m    478\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(n_more_estimators)\n\u001b[1;32m    479\u001b[0m ]\n\u001b[1;32m    481\u001b[0m \u001b[38;5;66;03m# Parallel loop: we prefer the threading backend as the Cython code\u001b[39;00m\n\u001b[1;32m    482\u001b[0m \u001b[38;5;66;03m# for fitting the trees is internally releasing the Python GIL\u001b[39;00m\n\u001b[1;32m    483\u001b[0m \u001b[38;5;66;03m# making threading more efficient than multiprocessing in\u001b[39;00m\n\u001b[1;32m    484\u001b[0m \u001b[38;5;66;03m# that case. However, for joblib 0.12+ we respect any\u001b[39;00m\n\u001b[1;32m    485\u001b[0m \u001b[38;5;66;03m# parallel_backend contexts set at a higher level,\u001b[39;00m\n\u001b[1;32m    486\u001b[0m \u001b[38;5;66;03m# since correctness does not rely on using threads.\u001b[39;00m\n\u001b[0;32m--> 487\u001b[0m trees \u001b[38;5;241m=\u001b[39m \u001b[43mParallel\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    488\u001b[0m \u001b[43m    \u001b[49m\u001b[43mn_jobs\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mn_jobs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    489\u001b[0m \u001b[43m    \u001b[49m\u001b[43mverbose\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mverbose\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    490\u001b[0m \u001b[43m    \u001b[49m\u001b[43mprefer\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mthreads\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    491\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    492\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdelayed\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_parallel_build_trees\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    493\u001b[0m \u001b[43m        \u001b[49m\u001b[43mt\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    494\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbootstrap\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    495\u001b[0m \u001b[43m        \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    496\u001b[0m \u001b[43m        \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    497\u001b[0m \u001b[43m        \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    498\u001b[0m \u001b[43m        \u001b[49m\u001b[43mi\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    499\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43mlen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mtrees\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    500\u001b[0m \u001b[43m        \u001b[49m\u001b[43mverbose\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mverbose\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    501\u001b[0m \u001b[43m        \u001b[49m\u001b[43mclass_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mclass_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    502\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_samples_bootstrap\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_samples_bootstrap\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    503\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    504\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    505\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mi\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mt\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43menumerate\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mtrees\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    506\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    508\u001b[0m \u001b[38;5;66;03m# Collect newly grown trees\u001b[39;00m\n\u001b[1;32m    509\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mestimators_\u001b[38;5;241m.\u001b[39mextend(trees)\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/parallel.py:82\u001b[0m, in \u001b[0;36mParallel.__call__\u001b[0;34m(self, iterable)\u001b[0m\n\u001b[1;32m     73\u001b[0m warning_filters \u001b[38;5;241m=\u001b[39m warnings\u001b[38;5;241m.\u001b[39mfilters\n\u001b[1;32m     74\u001b[0m iterable_with_config_and_warning_filters \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m     75\u001b[0m     (\n\u001b[1;32m     76\u001b[0m         _with_config_and_warning_filters(delayed_func, config, warning_filters),\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     80\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m delayed_func, args, kwargs \u001b[38;5;129;01min\u001b[39;00m iterable\n\u001b[1;32m     81\u001b[0m )\n\u001b[0;32m---> 82\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__call__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43miterable_with_config_and_warning_filters\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/code/joblib/joblib/parallel.py:1979\u001b[0m, in \u001b[0;36mParallel.__call__\u001b[0;34m(self, iterable)\u001b[0m\n\u001b[1;32m   1977\u001b[0m     output \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_sequential_output(iterable)\n\u001b[1;32m   1978\u001b[0m     \u001b[38;5;28mnext\u001b[39m(output)\n\u001b[0;32m-> 1979\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m output \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mreturn_generator \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;43mlist\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43moutput\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1981\u001b[0m \u001b[38;5;66;03m# Let's create an ID that uniquely identifies the current call. If the\u001b[39;00m\n\u001b[1;32m   1982\u001b[0m \u001b[38;5;66;03m# call is interrupted early and that the same instance is immediately\u001b[39;00m\n\u001b[1;32m   1983\u001b[0m \u001b[38;5;66;03m# reused, this id will be used to prevent workers that were\u001b[39;00m\n\u001b[1;32m   1984\u001b[0m \u001b[38;5;66;03m# concurrently finalizing a task from the previous call to run the\u001b[39;00m\n\u001b[1;32m   1985\u001b[0m \u001b[38;5;66;03m# callback.\u001b[39;00m\n\u001b[1;32m   1986\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_lock:\n",
+      "File \u001b[0;32m~/code/joblib/joblib/parallel.py:1907\u001b[0m, in \u001b[0;36mParallel._get_sequential_output\u001b[0;34m(self, iterable)\u001b[0m\n\u001b[1;32m   1905\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_dispatched_batches \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m   1906\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_dispatched_tasks \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[0;32m-> 1907\u001b[0m res \u001b[38;5;241m=\u001b[39m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1908\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_completed_tasks \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m   1909\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprint_progress()\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/parallel.py:147\u001b[0m, in \u001b[0;36m_FuncWrapper.__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    145\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m config_context(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mconfig), warnings\u001b[38;5;241m.\u001b[39mcatch_warnings():\n\u001b[1;32m    146\u001b[0m     warnings\u001b[38;5;241m.\u001b[39mfilters \u001b[38;5;241m=\u001b[39m warning_filters\n\u001b[0;32m--> 147\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfunction\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/ensemble/_forest.py:197\u001b[0m, in \u001b[0;36m_parallel_build_trees\u001b[0;34m(tree, bootstrap, X, y, sample_weight, tree_idx, n_trees, verbose, class_weight, n_samples_bootstrap, missing_values_in_feature_mask)\u001b[0m\n\u001b[1;32m    189\u001b[0m     tree\u001b[38;5;241m.\u001b[39m_fit(\n\u001b[1;32m    190\u001b[0m         X,\n\u001b[1;32m    191\u001b[0m         y,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    194\u001b[0m         missing_values_in_feature_mask\u001b[38;5;241m=\u001b[39mmissing_values_in_feature_mask,\n\u001b[1;32m    195\u001b[0m     )\n\u001b[1;32m    196\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 197\u001b[0m     \u001b[43mtree\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_fit\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    198\u001b[0m \u001b[43m        \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    199\u001b[0m \u001b[43m        \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    200\u001b[0m \u001b[43m        \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msample_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    201\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcheck_input\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    202\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    203\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    205\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m tree\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/tree/_classes.py:478\u001b[0m, in \u001b[0;36mBaseDecisionTree._fit\u001b[0;34m(self, X, y, sample_weight, check_input, missing_values_in_feature_mask)\u001b[0m\n\u001b[1;32m    475\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_classes_ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_classes_[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    476\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclasses_ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclasses_[\u001b[38;5;241m0\u001b[39m]\n\u001b[0;32m--> 478\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_prune_tree\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    480\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/tree/_classes.py:612\u001b[0m, in \u001b[0;36mBaseDecisionTree._prune_tree\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    610\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m_prune_tree\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m    611\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Prune tree using Minimal Cost-Complexity Pruning.\"\"\"\u001b[39;00m\n\u001b[0;32m--> 612\u001b[0m     \u001b[43mcheck_is_fitted\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    614\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mccp_alpha \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0.0\u001b[39m:\n\u001b[1;32m    615\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/validation.py:1749\u001b[0m, in \u001b[0;36mcheck_is_fitted\u001b[0;34m(estimator, attributes, msg, all_or_any)\u001b[0m\n\u001b[1;32m   1746\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(estimator, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfit\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n\u001b[1;32m   1747\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m is not an estimator instance.\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m (estimator))\n\u001b[0;32m-> 1749\u001b[0m tags \u001b[38;5;241m=\u001b[39m \u001b[43mget_tags\u001b[49m\u001b[43m(\u001b[49m\u001b[43mestimator\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1751\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m tags\u001b[38;5;241m.\u001b[39mrequires_fit \u001b[38;5;129;01mand\u001b[39;00m attributes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m   1752\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/_tags.py:393\u001b[0m, in \u001b[0;36mget_tags\u001b[0;34m(estimator)\u001b[0m\n\u001b[1;32m    367\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mget_tags\u001b[39m(estimator) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Tags:\n\u001b[1;32m    368\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Get estimator tags.\u001b[39;00m\n\u001b[1;32m    369\u001b[0m \n\u001b[1;32m    370\u001b[0m \u001b[38;5;124;03m    :class:`~sklearn.BaseEstimator` provides the estimator tags machinery.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    390\u001b[0m \u001b[38;5;124;03m        The estimator tags.\u001b[39;00m\n\u001b[1;32m    391\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 393\u001b[0m     tag_provider \u001b[38;5;241m=\u001b[39m \u001b[43m_find_tags_provider\u001b[49m\u001b[43m(\u001b[49m\u001b[43mestimator\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    395\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m tag_provider \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m__sklearn_tags__\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m    396\u001b[0m         \u001b[38;5;66;03m# TODO(1.7): turn the warning into an error\u001b[39;00m\n\u001b[1;32m    397\u001b[0m         \u001b[38;5;28;01mtry\u001b[39;00m:\n",
+      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/_tags.py:327\u001b[0m, in \u001b[0;36m_find_tags_provider\u001b[0;34m(estimator, warn)\u001b[0m\n\u001b[1;32m    325\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_more_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mvars\u001b[39m(klass):\n\u001b[1;32m    326\u001b[0m     tags_provider\u001b[38;5;241m.\u001b[39mappend(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_more_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 327\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_get_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28;43mvars\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mklass\u001b[49m\u001b[43m)\u001b[49m:\n\u001b[1;32m    328\u001b[0m     tags_provider\u001b[38;5;241m.\u001b[39mappend(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_get_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    329\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m__sklearn_tags__\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mvars\u001b[39m(klass):\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
      ]
     }
    ],
    "source": [
+    "STAT_TEST_DIM = 30\n",
+    "N_STOCHASTIC_FITS = 100\n",
+    "N_STOCHASTIC_ESTIMATORS = 36  # measured a posteriori\n",
+    "# BONFERRONI_CORRECTION = 1 / (N_STOCHASTIC_ESTIMATORS * STAT_TEST_DIM)\n",
+    "BONFERRONI_CORRECTION = 1 / STAT_TEST_DIM\n",
+    "\n",
+    "TEST_THRESHOLD = 0.05 * BONFERRONI_CORRECTION\n",
+    "\n",
+    "\n",
     "statistical_test_results = []\n",
     "deterministic_test_results = []\n",
     "missing_sample_weight_support = []\n",
@@ -886,11 +414,13 @@
     "        result = check_weighted_repeated_estimator_fit_equivalence(\n",
     "            est,\n",
     "            test_name=\"kstest\",\n",
-    "            n_stochastic_fits=30,\n",
+    "            stat_test_dim=STAT_TEST_DIM,\n",
+    "            n_stochastic_fits=N_STOCHASTIC_FITS,\n",
+    "            random_state=0,\n",
     "        )\n",
-    "        pass_or_fail = \"✅\" if result.min_p_value > 0.05 else \"❌\"\n",
+    "        pass_or_fail = \"✅\" if result.min_p_value > TEST_THRESHOLD else \"❌\"\n",
     "        print(\n",
-    "            f\"{pass_or_fail} {est_name}: (p_value: {result.min_p_value:.3f}\"\n",
+    "            f\"{pass_or_fail} {est_name}: (min p_value: {result.min_p_value:.3f})\"\n",
     "        )\n",
     "        statistical_test_results.append(result)\n",
     "    except UnexpectedDeterministicPredictions:\n",
@@ -915,22 +445,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ 19 passed the deterministic test\n",
-      "❌ 4 failed the deterministic test\n",
-      "✅ 14 passed the statistical test\n",
-      "❌ 22 failed the statistical test\n",
-      "❌ 3 other errors\n",
-      "⚠ 112 estimators lack sample_weight support\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\n",
     "    f\"✅ {len([r for r in deterministic_test_results if r[1] is None])} \"\n",
@@ -941,11 +458,11 @@
     "    \"failed the deterministic test\"\n",
     ")\n",
     "print(\n",
-    "    f\"✅ {len([r for r in statistical_test_results if r.min_p_value > 0.05])} \"\n",
+    "    f\"✅ {len([r for r in statistical_test_results if r.min_p_value > TEST_THRESHOLD])} \"\n",
     "    \"passed the statistical test\"\n",
     ")\n",
     "print(\n",
-    "    f\"❌ {len([r for r in statistical_test_results if r.min_p_value <= 0.05])} \"\n",
+    "    f\"❌ {len([r for r in statistical_test_results if r.min_p_value <= TEST_THRESHOLD])} \"\n",
     "    \"failed the statistical test\"\n",
     ")\n",
     "print(f\"❌ {len(errors)} other errors\")\n",
@@ -965,301 +482,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>estimator_name</th>\n",
-       "      <th>min_p_value</th>\n",
-       "      <th>mean_p_value</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>35</th>\n",
-       "      <td>SVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.000006</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>34</th>\n",
-       "      <td>SGDRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.000010</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>HistGradientBoostingRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.132291</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>HistGradientBoostingClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.052410</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>LinearSVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.000003</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>Perceptron</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.003939</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.119047</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>NuSVC</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.019803</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>33</th>\n",
-       "      <td>SGDClassifier</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.006417</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>LassoCV</td>\n",
-       "      <td>1.691123e-17</td>\n",
-       "      <td>0.026932</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>RandomForestClassifier</td>\n",
-       "      <td>1.014674e-15</td>\n",
-       "      <td>0.233731</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>LogisticRegression</td>\n",
-       "      <td>1.014674e-15</td>\n",
-       "      <td>0.124649</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>BaggingClassifier</td>\n",
-       "      <td>8.246510e-12</td>\n",
-       "      <td>0.292787</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>LinearSVR</td>\n",
-       "      <td>8.466416e-10</td>\n",
-       "      <td>0.112182</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaggingRegressor</td>\n",
-       "      <td>6.531236e-09</td>\n",
-       "      <td>0.127654</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>32</th>\n",
-       "      <td>Ridge</td>\n",
-       "      <td>6.531236e-09</td>\n",
-       "      <td>0.000180</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>8.737804e-05</td>\n",
-       "      <td>0.615249</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>DecisionTreeRegressor</td>\n",
-       "      <td>8.995777e-04</td>\n",
-       "      <td>0.787147</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>MiniBatchKMeans</td>\n",
-       "      <td>6.548396e-03</td>\n",
-       "      <td>0.426149</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>BisectingKMeans</td>\n",
-       "      <td>6.548396e-03</td>\n",
-       "      <td>0.488554</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>KMeans</td>\n",
-       "      <td>1.564339e-02</td>\n",
-       "      <td>0.563081</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>AdaBoostRegressor</td>\n",
-       "      <td>3.458008e-02</td>\n",
-       "      <td>0.566948</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>7.088799e-02</td>\n",
-       "      <td>0.704404</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31</th>\n",
-       "      <td>RandomTreesEmbedding</td>\n",
-       "      <td>7.088799e-02</td>\n",
-       "      <td>0.593194</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>KBinsDiscretizer</td>\n",
-       "      <td>7.088799e-02</td>\n",
-       "      <td>0.554314</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>1.350035e-01</td>\n",
-       "      <td>0.726652</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>GradientBoostingClassifier</td>\n",
-       "      <td>2.390730e-01</td>\n",
-       "      <td>0.732647</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>9.578463e-01</td>\n",
-       "      <td>0.995553</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>MLPClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>MLPRegressor</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>ExtraTreesClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>ExtraTreeClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>ElasticNetCV</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>ElasticNet</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>DummyClassifier</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>Lasso</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                    estimator_name   min_p_value  mean_p_value\n",
-       "35                             SVC  1.691123e-17      0.000006\n",
-       "34                    SGDRegressor  1.691123e-17      0.000010\n",
-       "16   HistGradientBoostingRegressor  1.691123e-17      0.132291\n",
-       "15  HistGradientBoostingClassifier  1.691123e-17      0.052410\n",
-       "21                       LinearSVC  1.691123e-17      0.000003\n",
-       "28                      Perceptron  1.691123e-17      0.003939\n",
-       "30           RandomForestRegressor  1.691123e-17      0.119047\n",
-       "27                           NuSVC  1.691123e-17      0.019803\n",
-       "33                   SGDClassifier  1.691123e-17      0.006417\n",
-       "20                         LassoCV  1.691123e-17      0.026932\n",
-       "29          RandomForestClassifier  1.014674e-15      0.233731\n",
-       "23              LogisticRegression  1.014674e-15      0.124649\n",
-       "1                BaggingClassifier  8.246510e-12      0.292787\n",
-       "22                       LinearSVR  8.466416e-10      0.112182\n",
-       "2                 BaggingRegressor  6.531236e-09      0.127654\n",
-       "32                           Ridge  6.531236e-09      0.000180\n",
-       "12             ExtraTreesRegressor  8.737804e-05      0.615249\n",
-       "5            DecisionTreeRegressor  8.995777e-04      0.787147\n",
-       "26                 MiniBatchKMeans  6.548396e-03      0.426149\n",
-       "3                  BisectingKMeans  6.548396e-03      0.488554\n",
-       "18                          KMeans  1.564339e-02      0.563081\n",
-       "0                AdaBoostRegressor  3.458008e-02      0.566948\n",
-       "10              ExtraTreeRegressor  7.088799e-02      0.704404\n",
-       "31            RandomTreesEmbedding  7.088799e-02      0.593194\n",
-       "17                KBinsDiscretizer  7.088799e-02      0.554314\n",
-       "14       GradientBoostingRegressor  1.350035e-01      0.726652\n",
-       "13      GradientBoostingClassifier  2.390730e-01      0.732647\n",
-       "4           DecisionTreeClassifier  9.578463e-01      0.995553\n",
-       "24                   MLPClassifier  1.000000e+00      1.000000\n",
-       "25                    MLPRegressor  1.000000e+00      1.000000\n",
-       "11            ExtraTreesClassifier  1.000000e+00      1.000000\n",
-       "9              ExtraTreeClassifier  1.000000e+00      1.000000\n",
-       "8                     ElasticNetCV  1.000000e+00      1.000000\n",
-       "7                       ElasticNet  1.000000e+00      1.000000\n",
-       "6                  DummyClassifier  1.000000e+00      1.000000\n",
-       "19                           Lasso  1.000000e+00      1.000000"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "results_df.sort_values(\"min_p_value\")[[\"estimator_name\", \"min_p_value\",\"mean_p_value\"]]"
    ]
@@ -1275,183 +500,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ HuberRegressor(): \n",
-      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
-      "Comparing the output of HuberRegressor.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
-      "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00051052\n",
-      "Max relative difference among violations: 7.5912896\n",
-      " ACTUAL: array([-2.323244e-05,  9.999910e-01,  2.000039e+00,  1.202210e+00,\n",
-      "        2.430282e+00,  9.999892e-01,  1.999998e+00,  2.000024e+00,\n",
-      "        1.656899e+00,  1.999991e+00,  1.576810e+00,  1.295011e+00,\n",
-      "        1.829514e+00,  1.000022e+00,  1.000070e+00])\n",
-      " DESIRED: array([-2.704185e-06,  9.999971e-01,  2.000005e+00,  1.202141e+00,\n",
-      "        2.430112e+00,  9.999871e-01,  1.999991e+00,  2.000007e+00,\n",
-      "        1.656642e+00,  1.999968e+00,  1.576735e+00,  1.294886e+00,\n",
-      "        1.829381e+00,  1.000010e+00,  9.995597e-01])\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
-      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
-      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
-      "    return fn(*args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
-      "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
-      "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
-      "    np_assert_allclose(\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
-      "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
-      "    return func(*args, **kwds)\n",
-      "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
-      "    raise AssertionError(msg)\n",
-      "AssertionError: \n",
-      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
-      "Comparing the output of HuberRegressor.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
-      "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00051052\n",
-      "Max relative difference among violations: 7.5912896\n",
-      " ACTUAL: array([-2.323244e-05,  9.999910e-01,  2.000039e+00,  1.202210e+00,\n",
-      "        2.430282e+00,  9.999892e-01,  1.999998e+00,  2.000024e+00,\n",
-      "        1.656899e+00,  1.999991e+00,  1.576810e+00,  1.295011e+00,\n",
-      "        1.829514e+00,  1.000022e+00,  1.000070e+00])\n",
-      " DESIRED: array([-2.704185e-06,  9.999971e-01,  2.000005e+00,  1.202141e+00,\n",
-      "        2.430112e+00,  9.999871e-01,  1.999991e+00,  2.000007e+00,\n",
-      "        1.656642e+00,  1.999968e+00,  1.576735e+00,  1.294886e+00,\n",
-      "        1.829381e+00,  1.000010e+00,  9.995597e-01])\n",
-      "\n",
-      "❌ IsotonicRegression(): Isotonic regression input X should be a 1d array or 2d array with 1 feature\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
-      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
-      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
-      "    return fn(*args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1560, in _check_sample_weight_equivalence\n",
-      "    estimator_repeated.fit(X_repeated, y=y_repeated, sample_weight=None)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/isotonic.py\", line 401, in fit\n",
-      "    X, y = self._build_y(X, y, sample_weight)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/isotonic.py\", line 316, in _build_y\n",
-      "    self._check_input_data_shape(X)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/isotonic.py\", line 300, in _check_input_data_shape\n",
-      "    raise ValueError(msg)\n",
-      "ValueError: Isotonic regression input X should be a 1d array or 2d array with 1 feature\n",
-      "\n",
-      "❌ NuSVR(): \n",
-      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
-      "Comparing the output of NuSVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
-      "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00305074\n",
-      "Max relative difference among violations: 0.34499784\n",
-      " ACTUAL: array([1.697759e-04, 9.998989e-01, 1.999758e+00, 1.316667e+00,\n",
-      "       1.577872e+00, 1.000017e+00, 2.000128e+00, 1.999764e+00,\n",
-      "       1.233518e+00, 2.000170e+00, 1.400195e+00, 1.397883e+00,\n",
-      "       1.430682e+00, 1.000631e+00, 9.999184e-01])\n",
-      " DESIRED: array([2.591989e-04, 9.998203e-01, 1.999778e+00, 1.316390e+00,\n",
-      "       1.580922e+00, 1.000526e+00, 2.000151e+00, 1.999443e+00,\n",
-      "       1.233376e+00, 1.999820e+00, 1.401014e+00, 1.398252e+00,\n",
-      "       1.432028e+00, 1.000286e+00, 1.000143e+00])\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
-      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
-      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
-      "    return fn(*args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
-      "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
-      "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
-      "    np_assert_allclose(\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
-      "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
-      "    return func(*args, **kwds)\n",
-      "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
-      "    raise AssertionError(msg)\n",
-      "AssertionError: \n",
-      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
-      "Comparing the output of NuSVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
-      "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00305074\n",
-      "Max relative difference among violations: 0.34499784\n",
-      " ACTUAL: array([1.697759e-04, 9.998989e-01, 1.999758e+00, 1.316667e+00,\n",
-      "       1.577872e+00, 1.000017e+00, 2.000128e+00, 1.999764e+00,\n",
-      "       1.233518e+00, 2.000170e+00, 1.400195e+00, 1.397883e+00,\n",
-      "       1.430682e+00, 1.000631e+00, 9.999184e-01])\n",
-      " DESIRED: array([2.591989e-04, 9.998203e-01, 1.999778e+00, 1.316390e+00,\n",
-      "       1.580922e+00, 1.000526e+00, 2.000151e+00, 1.999443e+00,\n",
-      "       1.233376e+00, 1.999820e+00, 1.401014e+00, 1.398252e+00,\n",
-      "       1.432028e+00, 1.000286e+00, 1.000143e+00])\n",
-      "\n",
-      "❌ SVR(): \n",
-      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
-      "Comparing the output of SVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
-      "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00266417\n",
-      "Max relative difference among violations: 0.00269241\n",
-      " ACTUAL: array([0.100011, 1.100002, 1.89998 , 1.327766, 1.553381, 1.099804,\n",
-      "       1.900507, 1.900239, 1.253786, 1.899847, 1.414408, 1.4019  ,\n",
-      "       1.440486, 1.100011, 1.099589])\n",
-      " DESIRED: array([0.100281, 1.100199, 1.900164, 1.327585, 1.556046, 1.099828,\n",
-      "       1.900122, 1.900199, 1.253611, 1.900075, 1.415291, 1.402263,\n",
-      "       1.441794, 1.099432, 1.0997  ])\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 29, in <module>\n",
-      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
-      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
-      "    return fn(*args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
-      "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
-      "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
-      "    np_assert_allclose(\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
-      "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
-      "    return func(*args, **kwds)\n",
-      "           ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
-      "    raise AssertionError(msg)\n",
-      "AssertionError: \n",
-      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
-      "Comparing the output of SVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
-      "Mismatched elements: 15 / 15 (100%)\n",
-      "Max absolute difference among violations: 0.00266417\n",
-      "Max relative difference among violations: 0.00269241\n",
-      " ACTUAL: array([0.100011, 1.100002, 1.89998 , 1.327766, 1.553381, 1.099804,\n",
-      "       1.900507, 1.900239, 1.253786, 1.899847, 1.414408, 1.4019  ,\n",
-      "       1.440486, 1.100011, 1.099589])\n",
-      " DESIRED: array([0.100281, 1.100199, 1.900164, 1.327585, 1.556046, 1.099828,\n",
-      "       1.900122, 1.900199, 1.253611, 1.900075, 1.415291, 1.402263,\n",
-      "       1.441794, 1.099432, 1.0997  ])\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "\n",
@@ -1475,97 +524,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "❌ KBinsDiscretizer(encode='ordinal', subsample=50): sample_weight.shape == (100,), expected (50,)!\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 44, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 83, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
-      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 260, in multifit_over_weighted_and_repeated\n",
-      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
-      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 190, in check_pipeline_and_fit\n",
-      "    est = est.fit(\n",
-      "          ^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/pipeline.py\", line 654, in fit\n",
-      "    Xt = self._fit(X, y, routed_params, raw_params=params)\n",
-      "         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/pipeline.py\", line 588, in _fit\n",
-      "    X, fitted_transformer = fit_transform_one_cached(\n",
-      "                            ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/joblib/memory.py\", line 312, in __call__\n",
-      "    return self.func(*args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/pipeline.py\", line 1551, in _fit_transform_one\n",
-      "    res = transformer.fit_transform(X, y, **params.get(\"fit_transform\", {}))\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_set_output.py\", line 319, in wrapped\n",
-      "    data_to_wrap = f(self, X, *args, **kwargs)\n",
-      "                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 921, in fit_transform\n",
-      "    return self.fit(X, y, **fit_params).transform(X)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/preprocessing/_discretization.py\", line 254, in fit\n",
-      "    sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)\n",
-      "                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 2192, in _check_sample_weight\n",
-      "    raise ValueError(\n",
-      "ValueError: sample_weight.shape == (100,), expected (50,)!\n",
-      "\n",
-      "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_61613/841159171.py\", line 44, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 83, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
-      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 299, in multifit_over_weighted_and_repeated\n",
-      "    est_weighted = check_pipeline_and_fit(\n",
-      "                   ^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 197, in check_pipeline_and_fit\n",
-      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
-      "    return f(*args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
-      "    estimator.fit(X_subset, y_subset, **fit_params_subset)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
-      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
-      "                                        ^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
-      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 730, in _average\n",
-      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
-      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 575, in average\n",
-      "    raise ZeroDivisionError(\n",
-      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "\n",
@@ -1586,126 +545,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ARDRegression\n",
-      "AdditiveChi2Sampler\n",
-      "AffinityPropagation\n",
-      "AgglomerativeClustering\n",
-      "BernoulliRBM\n",
-      "Binarizer\n",
-      "Birch\n",
-      "CCA\n",
-      "ClassifierChain\n",
-      "ColumnTransformer\n",
-      "DictVectorizer\n",
-      "DictionaryLearning\n",
-      "FactorAnalysis\n",
-      "FastICA\n",
-      "FeatureAgglomeration\n",
-      "FeatureHasher\n",
-      "FeatureUnion\n",
-      "FixedThresholdClassifier\n",
-      "FunctionTransformer\n",
-      "GaussianProcessClassifier\n",
-      "GaussianProcessRegressor\n",
-      "GaussianRandomProjection\n",
-      "GenericUnivariateSelect\n",
-      "HDBSCAN\n",
-      "HashingVectorizer\n",
-      "IncrementalPCA\n",
-      "Isomap\n",
-      "KNNImputer\n",
-      "KNeighborsClassifier\n",
-      "KNeighborsRegressor\n",
-      "KNeighborsTransformer\n",
-      "KernelCenterer\n",
-      "KernelPCA\n",
-      "LabelBinarizer\n",
-      "LabelEncoder\n",
-      "LabelPropagation\n",
-      "LabelSpreading\n",
-      "Lars\n",
-      "LarsCV\n",
-      "LassoLars\n",
-      "LassoLarsCV\n",
-      "LassoLarsIC\n",
-      "LatentDirichletAllocation\n",
-      "LinearDiscriminantAnalysis\n",
-      "LocallyLinearEmbedding\n",
-      "MaxAbsScaler\n",
-      "MeanShift\n",
-      "MinMaxScaler\n",
-      "MiniBatchDictionaryLearning\n",
-      "MiniBatchNMF\n",
-      "MiniBatchSparsePCA\n",
-      "MissingIndicator\n",
-      "MultiLabelBinarizer\n",
-      "MultiTaskElasticNet\n",
-      "MultiTaskElasticNetCV\n",
-      "MultiTaskLasso\n",
-      "MultiTaskLassoCV\n",
-      "NMF\n",
-      "NearestCentroid\n",
-      "NeighborhoodComponentsAnalysis\n",
-      "Normalizer\n",
-      "Nystroem\n",
-      "OPTICS\n",
-      "OneHotEncoder\n",
-      "OneVsOneClassifier\n",
-      "OneVsRestClassifier\n",
-      "OrdinalEncoder\n",
-      "OrthogonalMatchingPursuit\n",
-      "OrthogonalMatchingPursuitCV\n",
-      "OutputCodeClassifier\n",
-      "PCA\n",
-      "PLSCanonical\n",
-      "PLSRegression\n",
-      "PLSSVD\n",
-      "PassiveAggressiveClassifier\n",
-      "PassiveAggressiveRegressor\n",
-      "PatchExtractor\n",
-      "PolynomialCountSketch\n",
-      "PolynomialFeatures\n",
-      "PowerTransformer\n",
-      "QuadraticDiscriminantAnalysis\n",
-      "QuantileTransformer\n",
-      "RBFSampler\n",
-      "RFE\n",
-      "RFECV\n",
-      "RadiusNeighborsClassifier\n",
-      "RadiusNeighborsRegressor\n",
-      "RadiusNeighborsTransformer\n",
-      "RegressorChain\n",
-      "RobustScaler\n",
-      "SelectFdr\n",
-      "SelectFpr\n",
-      "SelectFromModel\n",
-      "SelectFwe\n",
-      "SelectKBest\n",
-      "SelectPercentile\n",
-      "SelfTrainingClassifier\n",
-      "SequentialFeatureSelector\n",
-      "SimpleImputer\n",
-      "SkewedChi2Sampler\n",
-      "SparseCoder\n",
-      "SparsePCA\n",
-      "SparseRandomProjection\n",
-      "SpectralClustering\n",
-      "TSNE\n",
-      "TargetEncoder\n",
-      "TfidfTransformer\n",
-      "TheilSenRegressor\n",
-      "TransformedTargetRegressor\n",
-      "TruncatedSVD\n",
-      "TunedThresholdClassifierCV\n",
-      "VarianceThreshold\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for est_name in missing_sample_weight_support:\n",
     "    print(est_name)"
@@ -1728,7 +568,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -133,7 +133,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:06<00:00, 14.35it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 14.79it/s]\n"
      ]
     },
     {
@@ -149,7 +149,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:05<00:00, 18.28it/s]\n"
+      "100%|██████████| 100/100 [00:05<00:00, 17.85it/s]\n"
      ]
     },
     {
@@ -167,7 +167,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 57.63it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 55.39it/s]\n"
      ]
     },
     {
@@ -182,7 +182,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 59.36it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 58.00it/s]\n"
      ]
     },
     {
@@ -202,14 +202,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 272.56it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 227.59it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ BisectingKMeans: (min p_value: 0.036)\n",
+      "✅ BisectingKMeans: (min p_value: 0.004)\n",
       "⚠ CCA does not support sample_weight\n",
       "✅ CalibratedClassifierCV() passed the deterministic check\n",
       "✅ CategoricalNB() passed the deterministic check\n",
@@ -224,7 +224,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 883.00it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 645.68it/s]\n"
      ]
     },
     {
@@ -239,14 +239,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 924.94it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 930.29it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeRegressor: (min p_value: 0.000)\n",
+      "❌ DecisionTreeRegressor: (min p_value: 0.000)\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -256,7 +256,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 1897.86it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 1836.35it/s]\n"
      ]
     },
     {
@@ -272,7 +272,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 662.75it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 915.67it/s]\n"
      ]
     },
     {
@@ -287,7 +287,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:02<00:00, 44.54it/s]\n"
+      "100%|██████████| 100/100 [00:02<00:00, 40.78it/s]\n"
      ]
     },
     {
@@ -302,7 +302,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 910.40it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 843.14it/s]\n"
      ]
     },
     {
@@ -317,14 +317,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 801.96it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 923.34it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeRegressor: (min p_value: 0.001)\n",
+      "❌ ExtraTreeRegressor: (min p_value: 0.001)\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -332,33 +332,509 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " 56%|█████▌    | 56/100 [00:04<00:03, 12.20it/s]\n"
+      "100%|██████████| 100/100 [00:08<00:00, 12.47it/s]\n"
      ]
     },
     {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[5], line 47\u001b[0m\n\u001b[1;32m     45\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mEvaluating \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mest\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     46\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 47\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mcheck_weighted_repeated_estimator_fit_equivalence\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     48\u001b[0m \u001b[43m        \u001b[49m\u001b[43mest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     49\u001b[0m \u001b[43m        \u001b[49m\u001b[43mtest_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mkstest\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m     50\u001b[0m \u001b[43m        \u001b[49m\u001b[43mstat_test_dim\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mSTAT_TEST_DIM\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     51\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_stochastic_fits\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mN_STOCHASTIC_FITS\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     52\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrandom_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m     53\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     54\u001b[0m     pass_or_fail \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m✅\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m result\u001b[38;5;241m.\u001b[39mmin_p_value \u001b[38;5;241m>\u001b[39m CONFIDENCE_LEVEL \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m❌\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     55\u001b[0m     \u001b[38;5;28mprint\u001b[39m(\n\u001b[1;32m     56\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mpass_or_fail\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mest_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m: (min p_value: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mresult\u001b[38;5;241m.\u001b[39mmin_p_value\u001b[38;5;132;01m:\u001b[39;00m\u001b[38;5;124m.3f\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m)\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     57\u001b[0m     )\n",
-      "File \u001b[0;32m~/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py:83\u001b[0m, in \u001b[0;36mcheck_weighted_repeated_estimator_fit_equivalence\u001b[0;34m(est, test_name, n_samples_per_cv_group, n_cv_group, n_features, n_classes, max_sample_weight, n_stochastic_fits, stat_test_dim, random_state)\u001b[0m\n\u001b[1;32m     52\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mcheck_weighted_repeated_estimator_fit_equivalence\u001b[39m(\n\u001b[1;32m     53\u001b[0m     est,\n\u001b[1;32m     54\u001b[0m     test_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mkstest\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     62\u001b[0m     random_state\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     63\u001b[0m ):\n\u001b[1;32m     64\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Assess the correct use of weights for estimators with stochastic fits.\u001b[39;00m\n\u001b[1;32m     65\u001b[0m \n\u001b[1;32m     66\u001b[0m \u001b[38;5;124;03m    This function fits an estimator with different random seeds, either with\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     80\u001b[0m \n\u001b[1;32m     81\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 83\u001b[0m     predictions_weighted, predictions_repeated, _ \u001b[38;5;241m=\u001b[39m \u001b[43mmultifit_over_weighted_and_repeated\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     84\u001b[0m \u001b[43m        \u001b[49m\u001b[43mest\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     85\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_features\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_features\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     86\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_classes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_classes\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     87\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_stochastic_fits\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_stochastic_fits\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     88\u001b[0m \u001b[43m        \u001b[49m\u001b[43mstat_test_dim\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mstat_test_dim\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     89\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_samples_per_cv_group\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_samples_per_cv_group\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     90\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_cv_group\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_cv_group\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     91\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmax_sample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmax_sample_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     92\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrandom_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrandom_state\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     93\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     94\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m (\n\u001b[1;32m     95\u001b[0m         predictions_weighted\u001b[38;5;241m.\u001b[39mndim \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m3\u001b[39m\n\u001b[1;32m     96\u001b[0m     )  \u001b[38;5;66;03m# (n_stochastic_fits, n_test_data_points, prediction_dim)\u001b[39;00m\n\u001b[1;32m     97\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m predictions_weighted\u001b[38;5;241m.\u001b[39mshape \u001b[38;5;241m==\u001b[39m predictions_repeated\u001b[38;5;241m.\u001b[39mshape\n",
-      "File \u001b[0;32m~/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py:302\u001b[0m, in \u001b[0;36mmultifit_over_weighted_and_repeated\u001b[0;34m(est, n_stochastic_fits, stat_test_dim, n_samples_per_cv_group, n_cv_group, n_features, n_classes, test_pool_size, max_sample_weight, random_state)\u001b[0m\n\u001b[1;32m    297\u001b[0m \u001b[38;5;66;03m# Use different random seeds for the other group of fits to avoid\u001b[39;00m\n\u001b[1;32m    298\u001b[0m \u001b[38;5;66;03m# introducing an unwanted statistical dependency.\u001b[39;00m\n\u001b[1;32m    299\u001b[0m est_repeated \u001b[38;5;241m=\u001b[39m clone(est)\u001b[38;5;241m.\u001b[39mset_params(\n\u001b[1;32m    300\u001b[0m     random_state\u001b[38;5;241m=\u001b[39mseed \u001b[38;5;241m+\u001b[39m n_stochastic_fits, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mextra_params_repeated\n\u001b[1;32m    301\u001b[0m )\n\u001b[0;32m--> 302\u001b[0m est_weighted \u001b[38;5;241m=\u001b[39m \u001b[43mcheck_pipeline_and_fit\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    303\u001b[0m \u001b[43m    \u001b[49m\u001b[43mest_weighted\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    304\u001b[0m \u001b[43m    \u001b[49m\u001b[43mX_train\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    305\u001b[0m \u001b[43m    \u001b[49m\u001b[43my_train\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    306\u001b[0m \u001b[43m    \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msample_weight_train\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    307\u001b[0m \u001b[43m    \u001b[49m\u001b[43mseed\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mseed\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    308\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    309\u001b[0m est_repeated \u001b[38;5;241m=\u001b[39m check_pipeline_and_fit(\n\u001b[1;32m    310\u001b[0m     est_repeated,\n\u001b[1;32m    311\u001b[0m     X_resampled_by_weights,\n\u001b[1;32m    312\u001b[0m     y_resampled_by_weights,\n\u001b[1;32m    313\u001b[0m     seed\u001b[38;5;241m=\u001b[39mseed,\n\u001b[1;32m    314\u001b[0m )\n\u001b[1;32m    316\u001b[0m predictions_weighted \u001b[38;5;241m=\u001b[39m compute_predictions(est_weighted, X_test_diverse_subset)\n",
-      "File \u001b[0;32m~/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py:196\u001b[0m, in \u001b[0;36mcheck_pipeline_and_fit\u001b[0;34m(est, X, y, sample_weight, seed)\u001b[0m\n\u001b[1;32m    189\u001b[0m     est \u001b[38;5;241m=\u001b[39m est\u001b[38;5;241m.\u001b[39mfit(\n\u001b[1;32m    190\u001b[0m         X,\n\u001b[1;32m    191\u001b[0m         y,\n\u001b[1;32m    192\u001b[0m         transformer__sample_weight\u001b[38;5;241m=\u001b[39msample_weight,\n\u001b[1;32m    193\u001b[0m         ridge__sample_weight\u001b[38;5;241m=\u001b[39msample_weight,\n\u001b[1;32m    194\u001b[0m     )\n\u001b[1;32m    195\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 196\u001b[0m     est \u001b[38;5;241m=\u001b[39m \u001b[43mest\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msample_weight\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    197\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m est\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/base.py:1389\u001b[0m, in \u001b[0;36m_fit_context.<locals>.decorator.<locals>.wrapper\u001b[0;34m(estimator, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1382\u001b[0m     estimator\u001b[38;5;241m.\u001b[39m_validate_params()\n\u001b[1;32m   1384\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m config_context(\n\u001b[1;32m   1385\u001b[0m     skip_parameter_validation\u001b[38;5;241m=\u001b[39m(\n\u001b[1;32m   1386\u001b[0m         prefer_skip_nested_validation \u001b[38;5;129;01mor\u001b[39;00m global_skip_validation\n\u001b[1;32m   1387\u001b[0m     )\n\u001b[1;32m   1388\u001b[0m ):\n\u001b[0;32m-> 1389\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfit_method\u001b[49m\u001b[43m(\u001b[49m\u001b[43mestimator\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/ensemble/_forest.py:487\u001b[0m, in \u001b[0;36mBaseForest.fit\u001b[0;34m(self, X, y, sample_weight)\u001b[0m\n\u001b[1;32m    476\u001b[0m trees \u001b[38;5;241m=\u001b[39m [\n\u001b[1;32m    477\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_make_estimator(append\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m, random_state\u001b[38;5;241m=\u001b[39mrandom_state)\n\u001b[1;32m    478\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(n_more_estimators)\n\u001b[1;32m    479\u001b[0m ]\n\u001b[1;32m    481\u001b[0m \u001b[38;5;66;03m# Parallel loop: we prefer the threading backend as the Cython code\u001b[39;00m\n\u001b[1;32m    482\u001b[0m \u001b[38;5;66;03m# for fitting the trees is internally releasing the Python GIL\u001b[39;00m\n\u001b[1;32m    483\u001b[0m \u001b[38;5;66;03m# making threading more efficient than multiprocessing in\u001b[39;00m\n\u001b[1;32m    484\u001b[0m \u001b[38;5;66;03m# that case. However, for joblib 0.12+ we respect any\u001b[39;00m\n\u001b[1;32m    485\u001b[0m \u001b[38;5;66;03m# parallel_backend contexts set at a higher level,\u001b[39;00m\n\u001b[1;32m    486\u001b[0m \u001b[38;5;66;03m# since correctness does not rely on using threads.\u001b[39;00m\n\u001b[0;32m--> 487\u001b[0m trees \u001b[38;5;241m=\u001b[39m \u001b[43mParallel\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    488\u001b[0m \u001b[43m    \u001b[49m\u001b[43mn_jobs\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mn_jobs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    489\u001b[0m \u001b[43m    \u001b[49m\u001b[43mverbose\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mverbose\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    490\u001b[0m \u001b[43m    \u001b[49m\u001b[43mprefer\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mthreads\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    491\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    492\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdelayed\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_parallel_build_trees\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    493\u001b[0m \u001b[43m        \u001b[49m\u001b[43mt\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    494\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbootstrap\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    495\u001b[0m \u001b[43m        \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    496\u001b[0m \u001b[43m        \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    497\u001b[0m \u001b[43m        \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    498\u001b[0m \u001b[43m        \u001b[49m\u001b[43mi\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    499\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43mlen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mtrees\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    500\u001b[0m \u001b[43m        \u001b[49m\u001b[43mverbose\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mverbose\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    501\u001b[0m \u001b[43m        \u001b[49m\u001b[43mclass_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mclass_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    502\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_samples_bootstrap\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mn_samples_bootstrap\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    503\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    504\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    505\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mi\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mt\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43menumerate\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mtrees\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    506\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    508\u001b[0m \u001b[38;5;66;03m# Collect newly grown trees\u001b[39;00m\n\u001b[1;32m    509\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mestimators_\u001b[38;5;241m.\u001b[39mextend(trees)\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/parallel.py:82\u001b[0m, in \u001b[0;36mParallel.__call__\u001b[0;34m(self, iterable)\u001b[0m\n\u001b[1;32m     73\u001b[0m warning_filters \u001b[38;5;241m=\u001b[39m warnings\u001b[38;5;241m.\u001b[39mfilters\n\u001b[1;32m     74\u001b[0m iterable_with_config_and_warning_filters \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m     75\u001b[0m     (\n\u001b[1;32m     76\u001b[0m         _with_config_and_warning_filters(delayed_func, config, warning_filters),\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     80\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m delayed_func, args, kwargs \u001b[38;5;129;01min\u001b[39;00m iterable\n\u001b[1;32m     81\u001b[0m )\n\u001b[0;32m---> 82\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__call__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43miterable_with_config_and_warning_filters\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/joblib/joblib/parallel.py:1979\u001b[0m, in \u001b[0;36mParallel.__call__\u001b[0;34m(self, iterable)\u001b[0m\n\u001b[1;32m   1977\u001b[0m     output \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_sequential_output(iterable)\n\u001b[1;32m   1978\u001b[0m     \u001b[38;5;28mnext\u001b[39m(output)\n\u001b[0;32m-> 1979\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m output \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mreturn_generator \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;43mlist\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43moutput\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1981\u001b[0m \u001b[38;5;66;03m# Let's create an ID that uniquely identifies the current call. If the\u001b[39;00m\n\u001b[1;32m   1982\u001b[0m \u001b[38;5;66;03m# call is interrupted early and that the same instance is immediately\u001b[39;00m\n\u001b[1;32m   1983\u001b[0m \u001b[38;5;66;03m# reused, this id will be used to prevent workers that were\u001b[39;00m\n\u001b[1;32m   1984\u001b[0m \u001b[38;5;66;03m# concurrently finalizing a task from the previous call to run the\u001b[39;00m\n\u001b[1;32m   1985\u001b[0m \u001b[38;5;66;03m# callback.\u001b[39;00m\n\u001b[1;32m   1986\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_lock:\n",
-      "File \u001b[0;32m~/code/joblib/joblib/parallel.py:1907\u001b[0m, in \u001b[0;36mParallel._get_sequential_output\u001b[0;34m(self, iterable)\u001b[0m\n\u001b[1;32m   1905\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_dispatched_batches \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m   1906\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_dispatched_tasks \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[0;32m-> 1907\u001b[0m res \u001b[38;5;241m=\u001b[39m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1908\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_completed_tasks \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m   1909\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprint_progress()\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/parallel.py:147\u001b[0m, in \u001b[0;36m_FuncWrapper.__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    145\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m config_context(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mconfig), warnings\u001b[38;5;241m.\u001b[39mcatch_warnings():\n\u001b[1;32m    146\u001b[0m     warnings\u001b[38;5;241m.\u001b[39mfilters \u001b[38;5;241m=\u001b[39m warning_filters\n\u001b[0;32m--> 147\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfunction\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/ensemble/_forest.py:197\u001b[0m, in \u001b[0;36m_parallel_build_trees\u001b[0;34m(tree, bootstrap, X, y, sample_weight, tree_idx, n_trees, verbose, class_weight, n_samples_bootstrap, missing_values_in_feature_mask)\u001b[0m\n\u001b[1;32m    189\u001b[0m     tree\u001b[38;5;241m.\u001b[39m_fit(\n\u001b[1;32m    190\u001b[0m         X,\n\u001b[1;32m    191\u001b[0m         y,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    194\u001b[0m         missing_values_in_feature_mask\u001b[38;5;241m=\u001b[39mmissing_values_in_feature_mask,\n\u001b[1;32m    195\u001b[0m     )\n\u001b[1;32m    196\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m--> 197\u001b[0m     \u001b[43mtree\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_fit\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    198\u001b[0m \u001b[43m        \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    199\u001b[0m \u001b[43m        \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    200\u001b[0m \u001b[43m        \u001b[49m\u001b[43msample_weight\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msample_weight\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    201\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcheck_input\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    202\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmissing_values_in_feature_mask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    203\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    205\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m tree\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/tree/_classes.py:478\u001b[0m, in \u001b[0;36mBaseDecisionTree._fit\u001b[0;34m(self, X, y, sample_weight, check_input, missing_values_in_feature_mask)\u001b[0m\n\u001b[1;32m    475\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_classes_ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_classes_[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    476\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclasses_ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclasses_[\u001b[38;5;241m0\u001b[39m]\n\u001b[0;32m--> 478\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_prune_tree\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    480\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/tree/_classes.py:612\u001b[0m, in \u001b[0;36mBaseDecisionTree._prune_tree\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    610\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m_prune_tree\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m    611\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Prune tree using Minimal Cost-Complexity Pruning.\"\"\"\u001b[39;00m\n\u001b[0;32m--> 612\u001b[0m     \u001b[43mcheck_is_fitted\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    614\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mccp_alpha \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0.0\u001b[39m:\n\u001b[1;32m    615\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/validation.py:1749\u001b[0m, in \u001b[0;36mcheck_is_fitted\u001b[0;34m(estimator, attributes, msg, all_or_any)\u001b[0m\n\u001b[1;32m   1746\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(estimator, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfit\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n\u001b[1;32m   1747\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m is not an estimator instance.\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m (estimator))\n\u001b[0;32m-> 1749\u001b[0m tags \u001b[38;5;241m=\u001b[39m \u001b[43mget_tags\u001b[49m\u001b[43m(\u001b[49m\u001b[43mestimator\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1751\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m tags\u001b[38;5;241m.\u001b[39mrequires_fit \u001b[38;5;129;01mand\u001b[39;00m attributes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m   1752\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/_tags.py:393\u001b[0m, in \u001b[0;36mget_tags\u001b[0;34m(estimator)\u001b[0m\n\u001b[1;32m    367\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mget_tags\u001b[39m(estimator) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Tags:\n\u001b[1;32m    368\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Get estimator tags.\u001b[39;00m\n\u001b[1;32m    369\u001b[0m \n\u001b[1;32m    370\u001b[0m \u001b[38;5;124;03m    :class:`~sklearn.BaseEstimator` provides the estimator tags machinery.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    390\u001b[0m \u001b[38;5;124;03m        The estimator tags.\u001b[39;00m\n\u001b[1;32m    391\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 393\u001b[0m     tag_provider \u001b[38;5;241m=\u001b[39m \u001b[43m_find_tags_provider\u001b[49m\u001b[43m(\u001b[49m\u001b[43mestimator\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    395\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m tag_provider \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m__sklearn_tags__\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m    396\u001b[0m         \u001b[38;5;66;03m# TODO(1.7): turn the warning into an error\u001b[39;00m\n\u001b[1;32m    397\u001b[0m         \u001b[38;5;28;01mtry\u001b[39;00m:\n",
-      "File \u001b[0;32m~/code/scikit-learn/sklearn/utils/_tags.py:327\u001b[0m, in \u001b[0;36m_find_tags_provider\u001b[0;34m(estimator, warn)\u001b[0m\n\u001b[1;32m    325\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_more_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mvars\u001b[39m(klass):\n\u001b[1;32m    326\u001b[0m     tags_provider\u001b[38;5;241m.\u001b[39mappend(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_more_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 327\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_get_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28;43mvars\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mklass\u001b[49m\u001b[43m)\u001b[49m:\n\u001b[1;32m    328\u001b[0m     tags_provider\u001b[38;5;241m.\u001b[39mappend(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_get_tags\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    329\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m__sklearn_tags__\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mvars\u001b[39m(klass):\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ExtraTreesClassifier: (min p_value: 0.078)\n",
+      "Evaluating ExtraTreesRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:07<00:00, 12.82it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ExtraTreesRegressor: (min p_value: 0.006)\n",
+      "⚠ FactorAnalysis does not support sample_weight\n",
+      "⚠ FastICA does not support sample_weight\n",
+      "⚠ FeatureAgglomeration does not support sample_weight\n",
+      "⚠ FeatureHasher does not support sample_weight\n",
+      "⚠ FeatureUnion does not support sample_weight\n",
+      "⚠ FixedThresholdClassifier does not support sample_weight\n",
+      "⚠ FunctionTransformer does not support sample_weight\n",
+      "✅ GammaRegressor() passed the deterministic check\n",
+      "✅ GaussianNB() passed the deterministic check\n",
+      "⚠ GaussianProcessClassifier does not support sample_weight\n",
+      "⚠ GaussianProcessRegressor does not support sample_weight\n",
+      "⚠ GaussianRandomProjection does not support sample_weight\n",
+      "⚠ GenericUnivariateSelect does not support sample_weight\n",
+      "Evaluating GradientBoostingClassifier(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:20<00:00,  4.96it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ GradientBoostingClassifier: (min p_value: 0.024)\n",
+      "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:04<00:00, 23.11it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ GradientBoostingRegressor: (min p_value: 0.004)\n",
+      "⚠ HDBSCAN does not support sample_weight\n",
+      "⚠ HashingVectorizer does not support sample_weight\n",
+      "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:08<00:00, 11.21it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ HistGradientBoostingClassifier: (min p_value: 0.000)\n",
+      "Evaluating HistGradientBoostingRegressor(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:03<00:00, 30.57it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ HistGradientBoostingRegressor: (min p_value: 0.000)\n",
+      "❌ HuberRegressor() failed the deterministic check\n",
+      "⚠ IncrementalPCA does not support sample_weight\n",
+      "⚠ Isomap does not support sample_weight\n",
+      "❌ IsotonicRegression() failed the deterministic check\n",
+      "Evaluating KBinsDiscretizer(encode='ordinal', quantile_method='averaged_inverted_cdf',\n",
+      "                 subsample=50)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 271.13it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ KBinsDiscretizer: (min p_value: 0.024)\n",
+      "Evaluating KMeans(n_clusters=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 289.24it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ KMeans: (min p_value: 0.024)\n",
+      "⚠ KNNImputer does not support sample_weight\n",
+      "⚠ KNeighborsClassifier does not support sample_weight\n",
+      "⚠ KNeighborsRegressor does not support sample_weight\n",
+      "⚠ KNeighborsTransformer does not support sample_weight\n",
+      "⚠ KernelCenterer does not support sample_weight\n",
+      "⚠ KernelPCA does not support sample_weight\n",
+      "✅ KernelRidge() passed the deterministic check\n",
+      "⚠ LabelBinarizer does not support sample_weight\n",
+      "⚠ LabelEncoder does not support sample_weight\n",
+      "⚠ LabelPropagation does not support sample_weight\n",
+      "⚠ LabelSpreading does not support sample_weight\n",
+      "⚠ Lars does not support sample_weight\n",
+      "⚠ LarsCV does not support sample_weight\n",
+      "Evaluating Lasso(selection='random')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 873.64it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Lasso: (min p_value: 0.111)\n",
+      "Evaluating LassoCV(selection='random')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:02<00:00, 43.48it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ LassoCV: (min p_value: 0.016)\n",
+      "⚠ LassoLars does not support sample_weight\n",
+      "⚠ LassoLarsCV does not support sample_weight\n",
+      "⚠ LassoLarsIC does not support sample_weight\n",
+      "⚠ LatentDirichletAllocation does not support sample_weight\n",
+      "⚠ LinearDiscriminantAnalysis does not support sample_weight\n",
+      "✅ LinearRegression() passed the deterministic check\n",
+      "Evaluating LinearSVC(dual=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:01<00:00, 78.26it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ LinearSVC: (min p_value: 0.000)\n",
+      "Evaluating LinearSVR(dual=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 1214.09it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ LinearSVR: (min p_value: 0.000)\n",
+      "⚠ LocallyLinearEmbedding does not support sample_weight\n",
+      "Evaluating LogisticRegression(dual=True, max_iter=100000, solver='liblinear')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 231.75it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ LogisticRegression: (min p_value: 0.000)\n",
+      "Skipping LogisticRegressionCV\n",
+      "Evaluating MLPClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:08<00:00, 12.24it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ MLPClassifier: (min p_value: 0.036)\n",
+      "Evaluating MLPRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:06<00:00, 14.78it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ MLPRegressor: (min p_value: 0.054)\n",
+      "⚠ MaxAbsScaler does not support sample_weight\n",
+      "⚠ MeanShift does not support sample_weight\n",
+      "⚠ MinMaxScaler does not support sample_weight\n",
+      "⚠ MiniBatchDictionaryLearning does not support sample_weight\n",
+      "Evaluating MiniBatchKMeans(n_clusters=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 199.38it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ MiniBatchKMeans: (min p_value: 0.000)\n",
+      "⚠ MiniBatchNMF does not support sample_weight\n",
+      "⚠ MiniBatchSparsePCA does not support sample_weight\n",
+      "⚠ MissingIndicator does not support sample_weight\n",
+      "⚠ MultiLabelBinarizer does not support sample_weight\n",
+      "⚠ MultiOutputClassifier failed to instantiate: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'\n",
+      "⚠ MultiOutputRegressor failed to instantiate: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'\n",
+      "⚠ MultiTaskElasticNet does not support sample_weight\n",
+      "⚠ MultiTaskElasticNetCV does not support sample_weight\n",
+      "⚠ MultiTaskLasso does not support sample_weight\n",
+      "⚠ MultiTaskLassoCV does not support sample_weight\n",
+      "✅ MultinomialNB() passed the deterministic check\n",
+      "⚠ NMF does not support sample_weight\n",
+      "⚠ NearestCentroid does not support sample_weight\n",
+      "⚠ NeighborhoodComponentsAnalysis does not support sample_weight\n",
+      "⚠ Normalizer does not support sample_weight\n",
+      "Evaluating NuSVC(probability=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 243.10it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ NuSVC: (min p_value: 0.000)\n",
+      "❌ NuSVR() failed the deterministic check\n",
+      "⚠ Nystroem does not support sample_weight\n",
+      "⚠ OPTICS does not support sample_weight\n",
+      "⚠ OneHotEncoder does not support sample_weight\n",
+      "⚠ OneVsOneClassifier does not support sample_weight\n",
+      "⚠ OneVsRestClassifier does not support sample_weight\n",
+      "⚠ OrdinalEncoder does not support sample_weight\n",
+      "⚠ OrthogonalMatchingPursuit does not support sample_weight\n",
+      "⚠ OrthogonalMatchingPursuitCV does not support sample_weight\n",
+      "⚠ OutputCodeClassifier does not support sample_weight\n",
+      "⚠ PCA does not support sample_weight\n",
+      "⚠ PLSCanonical does not support sample_weight\n",
+      "⚠ PLSRegression does not support sample_weight\n",
+      "⚠ PLSSVD does not support sample_weight\n",
+      "⚠ PassiveAggressiveClassifier does not support sample_weight\n",
+      "⚠ PassiveAggressiveRegressor does not support sample_weight\n",
+      "⚠ PatchExtractor does not support sample_weight\n",
+      "Evaluating Perceptron(max_iter=100000)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 468.54it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ Perceptron: (min p_value: 0.000)\n",
+      "✅ PoissonRegressor() passed the deterministic check\n",
+      "⚠ PolynomialCountSketch does not support sample_weight\n",
+      "⚠ PolynomialFeatures does not support sample_weight\n",
+      "⚠ PowerTransformer does not support sample_weight\n",
+      "⚠ QuadraticDiscriminantAnalysis does not support sample_weight\n",
+      "✅ QuantileRegressor() passed the deterministic check\n",
+      "⚠ QuantileTransformer does not support sample_weight\n",
+      "Evaluating RANSACRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  3%|▎         | 3/100 [00:00<00:04, 22.05it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RANSACRegressor() error with: Weights sum to zero, can't be normalized\n",
+      "⚠ RBFSampler does not support sample_weight\n",
+      "⚠ RFE does not support sample_weight\n",
+      "⚠ RFECV does not support sample_weight\n",
+      "⚠ RadiusNeighborsClassifier does not support sample_weight\n",
+      "⚠ RadiusNeighborsRegressor does not support sample_weight\n",
+      "⚠ RadiusNeighborsTransformer does not support sample_weight\n",
+      "Evaluating RandomForestClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:10<00:00,  9.42it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RandomForestClassifier: (min p_value: 0.000)\n",
+      "Evaluating RandomForestRegressor(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:09<00:00, 10.02it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RandomForestRegressor: (min p_value: 0.000)\n",
+      "Evaluating RandomTreesEmbedding(n_estimators=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:01<00:00, 74.04it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ RandomTreesEmbedding: (min p_value: 0.024)\n",
+      "⚠ RegressorChain does not support sample_weight\n",
+      "Evaluating Ridge(max_iter=100000, solver='sag')\n",
+      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #920. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "✅ RidgeCV() passed the deterministic check\n",
+      "Evaluating RidgeClassifier(max_iter=100000, solver='saga')\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #899. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "✅ RidgeClassifierCV() passed the deterministic check\n",
+      "⚠ RobustScaler does not support sample_weight\n",
+      "Evaluating SGDClassifier(max_iter=100000)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 388.63it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ SGDClassifier: (min p_value: 0.000)\n",
+      "Evaluating SGDRegressor(max_iter=100000)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 631.57it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ SGDRegressor: (min p_value: 0.000)\n",
+      "Evaluating SVC(probability=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 299.82it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ SVC: (min p_value: 0.000)\n",
+      "❌ SVR() failed the deterministic check\n",
+      "⚠ SelectFdr does not support sample_weight\n",
+      "⚠ SelectFpr does not support sample_weight\n",
+      "⚠ SelectFromModel does not support sample_weight\n",
+      "⚠ SelectFwe does not support sample_weight\n",
+      "⚠ SelectKBest does not support sample_weight\n",
+      "⚠ SelectPercentile does not support sample_weight\n",
+      "⚠ SelfTrainingClassifier does not support sample_weight\n",
+      "⚠ SequentialFeatureSelector does not support sample_weight\n",
+      "⚠ SimpleImputer does not support sample_weight\n",
+      "⚠ SkewedChi2Sampler does not support sample_weight\n",
+      "⚠ SparseCoder does not support sample_weight\n",
+      "⚠ SparsePCA does not support sample_weight\n",
+      "⚠ SparseRandomProjection does not support sample_weight\n",
+      "⚠ SpectralClustering does not support sample_weight\n",
+      "✅ SplineTransformer() passed the deterministic check\n",
+      "⚠ StackingClassifier failed to instantiate: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
+      "⚠ StackingRegressor failed to instantiate: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'\n",
+      "✅ StandardScaler() passed the deterministic check\n",
+      "⚠ TSNE does not support sample_weight\n",
+      "⚠ TargetEncoder does not support sample_weight\n",
+      "⚠ TfidfTransformer does not support sample_weight\n",
+      "⚠ TheilSenRegressor does not support sample_weight\n",
+      "⚠ TransformedTargetRegressor does not support sample_weight\n",
+      "⚠ TruncatedSVD does not support sample_weight\n",
+      "⚠ TunedThresholdClassifierCV does not support sample_weight\n",
+      "✅ TweedieRegressor() passed the deterministic check\n",
+      "⚠ VarianceThreshold does not support sample_weight\n",
+      "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
+      "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -445,9 +921,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ 19 passed the deterministic test\n",
+      "❌ 4 failed the deterministic test\n",
+      "✅ 19 passed the statistical test\n",
+      "❌ 17 failed the statistical test\n",
+      "❌ 3 other errors\n",
+      "⚠ 112 estimators lack sample_weight support\n"
+     ]
+    }
+   ],
    "source": [
     "print(\n",
     "    f\"✅ {len([r for r in deterministic_test_results if r[1] is None])} \"\n",
@@ -482,9 +971,549 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "estimator_name",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "min_p_value",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "mean_p_value",
+         "rawType": "float64",
+         "type": "float"
+        }
+       ],
+       "conversionMethod": "pd.DataFrame",
+       "ref": "f4b3cbb9-6179-454c-a088-3e70e5841f67",
+       "rows": [
+        [
+         "35",
+         "SVC",
+         "2.2087606931995054e-59",
+         "4.314065953263228e-05"
+        ],
+        [
+         "33",
+         "SGDClassifier",
+         "2.2087606931995054e-59",
+         "5.1840091263139014e-09"
+        ],
+        [
+         "29",
+         "Perceptron",
+         "2.2087606931995054e-59",
+         "1.9291340830534846e-06"
+        ],
+        [
+         "28",
+         "NuSVC",
+         "2.2087606931995054e-59",
+         "0.0111958730388815"
+        ],
+        [
+         "34",
+         "SGDRegressor",
+         "2.2087606931995054e-59",
+         "1.1190335893121966e-14"
+        ],
+        [
+         "16",
+         "HistGradientBoostingClassifier",
+         "2.2087606931995054e-59",
+         "0.016437057202205417"
+        ],
+        [
+         "31",
+         "RandomForestRegressor",
+         "4.395433779467016e-55",
+         "0.01391698325078679"
+        ],
+        [
+         "17",
+         "HistGradientBoostingRegressor",
+         "4.395433779467016e-55",
+         "0.06617922718612351"
+        ],
+        [
+         "22",
+         "LinearSVC",
+         "5.044580186155621e-47",
+         "1.0708779791061504e-06"
+        ],
+        [
+         "30",
+         "RandomForestClassifier",
+         "3.231287980676471e-37",
+         "0.04449568475987124"
+        ],
+        [
+         "24",
+         "LogisticRegression",
+         "3.7361767276571696e-36",
+         "0.002882910009783618"
+        ],
+        [
+         "3",
+         "BaggingRegressor",
+         "3.7361767276571696e-36",
+         "0.04613737603404432"
+        ],
+        [
+         "2",
+         "BaggingClassifier",
+         "2.6207113475674983e-22",
+         "0.1677309282852892"
+        ],
+        [
+         "23",
+         "LinearSVR",
+         "2.948425133635738e-11",
+         "0.0031611090461661838"
+        ],
+        [
+         "27",
+         "MiniBatchKMeans",
+         "6.281176788972264e-05",
+         "0.10175454816111522"
+        ],
+        [
+         "6",
+         "DecisionTreeRegressor",
+         "0.0002248739317492479",
+         "0.5300187942621497"
+        ],
+        [
+         "11",
+         "ExtraTreeRegressor",
+         "0.0007377026282063397",
+         "0.5007854227280222"
+        ],
+        [
+         "4",
+         "BisectingKMeans",
+         "0.0037294923618311367",
+         "0.40461616339858436"
+        ],
+        [
+         "15",
+         "GradientBoostingRegressor",
+         "0.0037294923618311367",
+         "0.6150537543812362"
+        ],
+        [
+         "13",
+         "ExtraTreesRegressor",
+         "0.0061340334218580265",
+         "0.5282442759087671"
+        ],
+        [
+         "21",
+         "LassoCV",
+         "0.015577131622877688",
+         "0.4399446356471764"
+        ],
+        [
+         "1",
+         "AdaBoostRegressor",
+         "0.015577131622877688",
+         "0.44366703638110194"
+        ],
+        [
+         "14",
+         "GradientBoostingClassifier",
+         "0.024055802841094577",
+         "0.505962569841026"
+        ],
+        [
+         "32",
+         "RandomTreesEmbedding",
+         "0.024055802841094577",
+         "0.5868843362441319"
+        ],
+        [
+         "9",
+         "ElasticNetCV",
+         "0.024055802841094577",
+         "0.36320364601997157"
+        ],
+        [
+         "19",
+         "KMeans",
+         "0.024055802841094577",
+         "0.5777609421432796"
+        ],
+        [
+         "18",
+         "KBinsDiscretizer",
+         "0.024055802841094577",
+         "0.49029584163753326"
+        ],
+        [
+         "25",
+         "MLPClassifier",
+         "0.03638428787491733",
+         "0.45207812407258346"
+        ],
+        [
+         "26",
+         "MLPRegressor",
+         "0.05390207893129876",
+         "0.6667449589218318"
+        ],
+        [
+         "0",
+         "AdaBoostClassifier",
+         "0.07822115797841851",
+         "0.5436899024552914"
+        ],
+        [
+         "12",
+         "ExtraTreesClassifier",
+         "0.07822115797841851",
+         "0.771872755662198"
+        ],
+        [
+         "20",
+         "Lasso",
+         "0.11119526053829192",
+         "0.7267857292560188"
+        ],
+        [
+         "5",
+         "DecisionTreeClassifier",
+         "0.21117008625127576",
+         "0.8070846939176107"
+        ],
+        [
+         "7",
+         "DummyClassifier",
+         "0.2819416298082479",
+         "0.8393830917461905"
+        ],
+        [
+         "8",
+         "ElasticNet",
+         "0.2819416298082479",
+         "0.7181746883251916"
+        ],
+        [
+         "10",
+         "ExtraTreeClassifier",
+         "0.9084105017744525",
+         "0.9885116258340203"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 36
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>estimator_name</th>\n",
+       "      <th>min_p_value</th>\n",
+       "      <th>mean_p_value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>SVC</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>4.314066e-05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>SGDClassifier</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>5.184009e-09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>Perceptron</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>1.929134e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>NuSVC</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>1.119587e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>34</th>\n",
+       "      <td>SGDRegressor</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>1.119034e-14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>HistGradientBoostingClassifier</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>1.643706e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
+       "      <td>4.395434e-55</td>\n",
+       "      <td>1.391698e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>HistGradientBoostingRegressor</td>\n",
+       "      <td>4.395434e-55</td>\n",
+       "      <td>6.617923e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>LinearSVC</td>\n",
+       "      <td>5.044580e-47</td>\n",
+       "      <td>1.070878e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>RandomForestClassifier</td>\n",
+       "      <td>3.231288e-37</td>\n",
+       "      <td>4.449568e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>3.736177e-36</td>\n",
+       "      <td>2.882910e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BaggingRegressor</td>\n",
+       "      <td>3.736177e-36</td>\n",
+       "      <td>4.613738e-02</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingClassifier</td>\n",
+       "      <td>2.620711e-22</td>\n",
+       "      <td>1.677309e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>LinearSVR</td>\n",
+       "      <td>2.948425e-11</td>\n",
+       "      <td>3.161109e-03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>MiniBatchKMeans</td>\n",
+       "      <td>6.281177e-05</td>\n",
+       "      <td>1.017545e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>2.248739e-04</td>\n",
+       "      <td>5.300188e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
+       "      <td>7.377026e-04</td>\n",
+       "      <td>5.007854e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>BisectingKMeans</td>\n",
+       "      <td>3.729492e-03</td>\n",
+       "      <td>4.046162e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
+       "      <td>3.729492e-03</td>\n",
+       "      <td>6.150538e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
+       "      <td>6.134033e-03</td>\n",
+       "      <td>5.282443e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>LassoCV</td>\n",
+       "      <td>1.557713e-02</td>\n",
+       "      <td>4.399446e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AdaBoostRegressor</td>\n",
+       "      <td>1.557713e-02</td>\n",
+       "      <td>4.436670e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>GradientBoostingClassifier</td>\n",
+       "      <td>2.405580e-02</td>\n",
+       "      <td>5.059626e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32</th>\n",
+       "      <td>RandomTreesEmbedding</td>\n",
+       "      <td>2.405580e-02</td>\n",
+       "      <td>5.868843e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>ElasticNetCV</td>\n",
+       "      <td>2.405580e-02</td>\n",
+       "      <td>3.632036e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>KMeans</td>\n",
+       "      <td>2.405580e-02</td>\n",
+       "      <td>5.777609e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>KBinsDiscretizer</td>\n",
+       "      <td>2.405580e-02</td>\n",
+       "      <td>4.902958e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>3.638429e-02</td>\n",
+       "      <td>4.520781e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>5.390208e-02</td>\n",
+       "      <td>6.667450e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AdaBoostClassifier</td>\n",
+       "      <td>7.822116e-02</td>\n",
+       "      <td>5.436899e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>ExtraTreesClassifier</td>\n",
+       "      <td>7.822116e-02</td>\n",
+       "      <td>7.718728e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>Lasso</td>\n",
+       "      <td>1.111953e-01</td>\n",
+       "      <td>7.267857e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
+       "      <td>2.111701e-01</td>\n",
+       "      <td>8.070847e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>DummyClassifier</td>\n",
+       "      <td>2.819416e-01</td>\n",
+       "      <td>8.393831e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>2.819416e-01</td>\n",
+       "      <td>7.181747e-01</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>ExtraTreeClassifier</td>\n",
+       "      <td>9.084105e-01</td>\n",
+       "      <td>9.885116e-01</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    estimator_name   min_p_value  mean_p_value\n",
+       "35                             SVC  2.208761e-59  4.314066e-05\n",
+       "33                   SGDClassifier  2.208761e-59  5.184009e-09\n",
+       "29                      Perceptron  2.208761e-59  1.929134e-06\n",
+       "28                           NuSVC  2.208761e-59  1.119587e-02\n",
+       "34                    SGDRegressor  2.208761e-59  1.119034e-14\n",
+       "16  HistGradientBoostingClassifier  2.208761e-59  1.643706e-02\n",
+       "31           RandomForestRegressor  4.395434e-55  1.391698e-02\n",
+       "17   HistGradientBoostingRegressor  4.395434e-55  6.617923e-02\n",
+       "22                       LinearSVC  5.044580e-47  1.070878e-06\n",
+       "30          RandomForestClassifier  3.231288e-37  4.449568e-02\n",
+       "24              LogisticRegression  3.736177e-36  2.882910e-03\n",
+       "3                 BaggingRegressor  3.736177e-36  4.613738e-02\n",
+       "2                BaggingClassifier  2.620711e-22  1.677309e-01\n",
+       "23                       LinearSVR  2.948425e-11  3.161109e-03\n",
+       "27                 MiniBatchKMeans  6.281177e-05  1.017545e-01\n",
+       "6            DecisionTreeRegressor  2.248739e-04  5.300188e-01\n",
+       "11              ExtraTreeRegressor  7.377026e-04  5.007854e-01\n",
+       "4                  BisectingKMeans  3.729492e-03  4.046162e-01\n",
+       "15       GradientBoostingRegressor  3.729492e-03  6.150538e-01\n",
+       "13             ExtraTreesRegressor  6.134033e-03  5.282443e-01\n",
+       "21                         LassoCV  1.557713e-02  4.399446e-01\n",
+       "1                AdaBoostRegressor  1.557713e-02  4.436670e-01\n",
+       "14      GradientBoostingClassifier  2.405580e-02  5.059626e-01\n",
+       "32            RandomTreesEmbedding  2.405580e-02  5.868843e-01\n",
+       "9                     ElasticNetCV  2.405580e-02  3.632036e-01\n",
+       "19                          KMeans  2.405580e-02  5.777609e-01\n",
+       "18                KBinsDiscretizer  2.405580e-02  4.902958e-01\n",
+       "25                   MLPClassifier  3.638429e-02  4.520781e-01\n",
+       "26                    MLPRegressor  5.390208e-02  6.667450e-01\n",
+       "0               AdaBoostClassifier  7.822116e-02  5.436899e-01\n",
+       "12            ExtraTreesClassifier  7.822116e-02  7.718728e-01\n",
+       "20                           Lasso  1.111953e-01  7.267857e-01\n",
+       "5           DecisionTreeClassifier  2.111701e-01  8.070847e-01\n",
+       "7                  DummyClassifier  2.819416e-01  8.393831e-01\n",
+       "8                       ElasticNet  2.819416e-01  7.181747e-01\n",
+       "10             ExtraTreeClassifier  9.084105e-01  9.885116e-01"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "results_df.sort_values(\"min_p_value\")[[\"estimator_name\", \"min_p_value\",\"mean_p_value\"]]"
    ]
@@ -498,9 +1527,185 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ HuberRegressor(): \n",
+      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
+      "Comparing the output of HuberRegressor.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
+      "Mismatched elements: 15 / 15 (100%)\n",
+      "Max absolute difference among violations: 0.00051052\n",
+      "Max relative difference among violations: 7.5912896\n",
+      " ACTUAL: array([-2.323244e-05,  9.999910e-01,  2.000039e+00,  1.202210e+00,\n",
+      "        2.430282e+00,  9.999892e-01,  1.999998e+00,  2.000024e+00,\n",
+      "        1.656899e+00,  1.999991e+00,  1.576810e+00,  1.295011e+00,\n",
+      "        1.829514e+00,  1.000022e+00,  1.000070e+00])\n",
+      " DESIRED: array([-2.704185e-06,  9.999971e-01,  2.000005e+00,  1.202141e+00,\n",
+      "        2.430112e+00,  9.999871e-01,  1.999991e+00,  2.000007e+00,\n",
+      "        1.656642e+00,  1.999968e+00,  1.576735e+00,  1.294886e+00,\n",
+      "        1.829381e+00,  1.000010e+00,  9.995597e-01])\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_47673/2096092967.py\", line 38, in <module>\n",
+      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
+      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
+      "    return fn(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
+      "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
+      "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
+      "    np_assert_allclose(\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
+      "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
+      "    return func(*args, **kwds)\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
+      "    raise AssertionError(msg)\n",
+      "AssertionError: \n",
+      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
+      "Comparing the output of HuberRegressor.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
+      "Mismatched elements: 15 / 15 (100%)\n",
+      "Max absolute difference among violations: 0.00051052\n",
+      "Max relative difference among violations: 7.5912896\n",
+      " ACTUAL: array([-2.323244e-05,  9.999910e-01,  2.000039e+00,  1.202210e+00,\n",
+      "        2.430282e+00,  9.999892e-01,  1.999998e+00,  2.000024e+00,\n",
+      "        1.656899e+00,  1.999991e+00,  1.576810e+00,  1.295011e+00,\n",
+      "        1.829514e+00,  1.000022e+00,  1.000070e+00])\n",
+      " DESIRED: array([-2.704185e-06,  9.999971e-01,  2.000005e+00,  1.202141e+00,\n",
+      "        2.430112e+00,  9.999871e-01,  1.999991e+00,  2.000007e+00,\n",
+      "        1.656642e+00,  1.999968e+00,  1.576735e+00,  1.294886e+00,\n",
+      "        1.829381e+00,  1.000010e+00,  9.995597e-01])\n",
+      "\n",
+      "❌ IsotonicRegression(): Isotonic regression input X should be a 1d array or 2d array with 1 feature\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_47673/2096092967.py\", line 38, in <module>\n",
+      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
+      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
+      "    return fn(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1560, in _check_sample_weight_equivalence\n",
+      "    estimator_repeated.fit(X_repeated, y=y_repeated, sample_weight=None)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/isotonic.py\", line 401, in fit\n",
+      "    X, y = self._build_y(X, y, sample_weight)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/isotonic.py\", line 316, in _build_y\n",
+      "    self._check_input_data_shape(X)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/isotonic.py\", line 300, in _check_input_data_shape\n",
+      "    raise ValueError(msg)\n",
+      "ValueError: Isotonic regression input X should be a 1d array or 2d array with 1 feature\n",
+      "\n",
+      "❌ NuSVR(): \n",
+      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
+      "Comparing the output of NuSVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
+      "Mismatched elements: 15 / 15 (100%)\n",
+      "Max absolute difference among violations: 0.00305074\n",
+      "Max relative difference among violations: 0.34499784\n",
+      " ACTUAL: array([1.697759e-04, 9.998989e-01, 1.999758e+00, 1.316667e+00,\n",
+      "       1.577872e+00, 1.000017e+00, 2.000128e+00, 1.999764e+00,\n",
+      "       1.233518e+00, 2.000170e+00, 1.400195e+00, 1.397883e+00,\n",
+      "       1.430682e+00, 1.000631e+00, 9.999184e-01])\n",
+      " DESIRED: array([2.591989e-04, 9.998203e-01, 1.999778e+00, 1.316390e+00,\n",
+      "       1.580922e+00, 1.000526e+00, 2.000151e+00, 1.999443e+00,\n",
+      "       1.233376e+00, 1.999820e+00, 1.401014e+00, 1.398252e+00,\n",
+      "       1.432028e+00, 1.000286e+00, 1.000143e+00])\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_47673/2096092967.py\", line 38, in <module>\n",
+      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
+      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
+      "    return fn(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
+      "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
+      "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
+      "    np_assert_allclose(\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
+      "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
+      "    return func(*args, **kwds)\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
+      "    raise AssertionError(msg)\n",
+      "AssertionError: \n",
+      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
+      "Comparing the output of NuSVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
+      "Mismatched elements: 15 / 15 (100%)\n",
+      "Max absolute difference among violations: 0.00305074\n",
+      "Max relative difference among violations: 0.34499784\n",
+      " ACTUAL: array([1.697759e-04, 9.998989e-01, 1.999758e+00, 1.316667e+00,\n",
+      "       1.577872e+00, 1.000017e+00, 2.000128e+00, 1.999764e+00,\n",
+      "       1.233518e+00, 2.000170e+00, 1.400195e+00, 1.397883e+00,\n",
+      "       1.430682e+00, 1.000631e+00, 9.999184e-01])\n",
+      " DESIRED: array([2.591989e-04, 9.998203e-01, 1.999778e+00, 1.316390e+00,\n",
+      "       1.580922e+00, 1.000526e+00, 2.000151e+00, 1.999443e+00,\n",
+      "       1.233376e+00, 1.999820e+00, 1.401014e+00, 1.398252e+00,\n",
+      "       1.432028e+00, 1.000286e+00, 1.000143e+00])\n",
+      "\n",
+      "❌ SVR(): \n",
+      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
+      "Comparing the output of SVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
+      "Mismatched elements: 15 / 15 (100%)\n",
+      "Max absolute difference among violations: 0.00266417\n",
+      "Max relative difference among violations: 0.00269241\n",
+      " ACTUAL: array([0.100011, 1.100002, 1.89998 , 1.327766, 1.553381, 1.099804,\n",
+      "       1.900507, 1.900239, 1.253786, 1.899847, 1.414408, 1.4019  ,\n",
+      "       1.440486, 1.100011, 1.099589])\n",
+      " DESIRED: array([0.100281, 1.100199, 1.900164, 1.327585, 1.556046, 1.099828,\n",
+      "       1.900122, 1.900199, 1.253611, 1.900075, 1.415291, 1.402263,\n",
+      "       1.441794, 1.099432, 1.0997  ])\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_47673/2096092967.py\", line 38, in <module>\n",
+      "    check_sample_weight_equivalence_on_dense_data(est_name, est)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1576, in check_sample_weight_equivalence_on_dense_data\n",
+      "    _check_sample_weight_equivalence(name, estimator_orig, sparse_container=None)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 147, in wrapper\n",
+      "    return fn(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/estimator_checks.py\", line 1572, in _check_sample_weight_equivalence\n",
+      "    assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 285, in assert_allclose_dense_sparse\n",
+      "    assert_allclose(x, y, rtol=rtol, atol=atol, err_msg=err_msg)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_testing.py\", line 239, in assert_allclose\n",
+      "    np_assert_allclose(\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 1691, in assert_allclose\n",
+      "    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/contextlib.py\", line 81, in inner\n",
+      "    return func(*args, **kwds)\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/testing/_private/utils.py\", line 889, in assert_array_compare\n",
+      "    raise AssertionError(msg)\n",
+      "AssertionError: \n",
+      "Not equal to tolerance rtol=1e-07, atol=1e-09\n",
+      "Comparing the output of SVR.predict revealed that fitting with `sample_weight` is not equivalent to fitting with removed or repeated data points.\n",
+      "Mismatched elements: 15 / 15 (100%)\n",
+      "Max absolute difference among violations: 0.00266417\n",
+      "Max relative difference among violations: 0.00269241\n",
+      " ACTUAL: array([0.100011, 1.100002, 1.89998 , 1.327766, 1.553381, 1.099804,\n",
+      "       1.900507, 1.900239, 1.253786, 1.899847, 1.414408, 1.4019  ,\n",
+      "       1.440486, 1.100011, 1.099589])\n",
+      " DESIRED: array([0.100281, 1.100199, 1.900164, 1.327585, 1.556046, 1.099828,\n",
+      "       1.900122, 1.900199, 1.253611, 1.900075, 1.415291, 1.402263,\n",
+      "       1.441794, 1.099432, 1.0997  ])\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "\n",
@@ -522,9 +1727,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_47673/2096092967.py\", line 49, in <module>\n",
+      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 83, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
+      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 302, in multifit_over_weighted_and_repeated\n",
+      "    est_weighted = check_pipeline_and_fit(\n",
+      "                   ^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 196, in check_pipeline_and_fit\n",
+      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
+      "    return f(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
+      "    estimator.fit(X_subset, y_subset, **fit_params_subset)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
+      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
+      "                                        ^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
+      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 717, in _average\n",
+      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
+      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "❌ Ridge(max_iter=100000, solver='sag'): Floating-point under-/overflow occurred at epoch #920. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_47673/2096092967.py\", line 49, in <module>\n",
+      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 83, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
+      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 259, in multifit_over_weighted_and_repeated\n",
+      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 196, in check_pipeline_and_fit\n",
+      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1249, in fit\n",
+      "    return super().fit(X, y, sample_weight=sample_weight)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
+      "                                             ^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "    coef_, n_iter_, _ = sag_solver(\n",
+      "                        ^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
+      "    num_seen, n_iter_ = sag(\n",
+      "                        ^^^^\n",
+      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #920. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga'): Floating-point under-/overflow occurred at epoch #899. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_47673/2096092967.py\", line 49, in <module>\n",
+      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 83, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "    predictions_weighted, predictions_repeated, _ = multifit_over_weighted_and_repeated(\n",
+      "                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 259, in multifit_over_weighted_and_repeated\n",
+      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 196, in check_pipeline_and_fit\n",
+      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1571, in fit\n",
+      "    super().fit(X, Y, sample_weight=sample_weight)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
+      "                                             ^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "    coef_, n_iter_, _ = sag_solver(\n",
+      "                        ^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
+      "    num_seen, n_iter_ = sag(\n",
+      "                        ^^^^\n",
+      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #899. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "import sys\n",
     "\n",
@@ -543,9 +1856,128 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ARDRegression\n",
+      "AdditiveChi2Sampler\n",
+      "AffinityPropagation\n",
+      "AgglomerativeClustering\n",
+      "BernoulliRBM\n",
+      "Binarizer\n",
+      "Birch\n",
+      "CCA\n",
+      "ClassifierChain\n",
+      "ColumnTransformer\n",
+      "DictVectorizer\n",
+      "DictionaryLearning\n",
+      "FactorAnalysis\n",
+      "FastICA\n",
+      "FeatureAgglomeration\n",
+      "FeatureHasher\n",
+      "FeatureUnion\n",
+      "FixedThresholdClassifier\n",
+      "FunctionTransformer\n",
+      "GaussianProcessClassifier\n",
+      "GaussianProcessRegressor\n",
+      "GaussianRandomProjection\n",
+      "GenericUnivariateSelect\n",
+      "HDBSCAN\n",
+      "HashingVectorizer\n",
+      "IncrementalPCA\n",
+      "Isomap\n",
+      "KNNImputer\n",
+      "KNeighborsClassifier\n",
+      "KNeighborsRegressor\n",
+      "KNeighborsTransformer\n",
+      "KernelCenterer\n",
+      "KernelPCA\n",
+      "LabelBinarizer\n",
+      "LabelEncoder\n",
+      "LabelPropagation\n",
+      "LabelSpreading\n",
+      "Lars\n",
+      "LarsCV\n",
+      "LassoLars\n",
+      "LassoLarsCV\n",
+      "LassoLarsIC\n",
+      "LatentDirichletAllocation\n",
+      "LinearDiscriminantAnalysis\n",
+      "LocallyLinearEmbedding\n",
+      "MaxAbsScaler\n",
+      "MeanShift\n",
+      "MinMaxScaler\n",
+      "MiniBatchDictionaryLearning\n",
+      "MiniBatchNMF\n",
+      "MiniBatchSparsePCA\n",
+      "MissingIndicator\n",
+      "MultiLabelBinarizer\n",
+      "MultiTaskElasticNet\n",
+      "MultiTaskElasticNetCV\n",
+      "MultiTaskLasso\n",
+      "MultiTaskLassoCV\n",
+      "NMF\n",
+      "NearestCentroid\n",
+      "NeighborhoodComponentsAnalysis\n",
+      "Normalizer\n",
+      "Nystroem\n",
+      "OPTICS\n",
+      "OneHotEncoder\n",
+      "OneVsOneClassifier\n",
+      "OneVsRestClassifier\n",
+      "OrdinalEncoder\n",
+      "OrthogonalMatchingPursuit\n",
+      "OrthogonalMatchingPursuitCV\n",
+      "OutputCodeClassifier\n",
+      "PCA\n",
+      "PLSCanonical\n",
+      "PLSRegression\n",
+      "PLSSVD\n",
+      "PassiveAggressiveClassifier\n",
+      "PassiveAggressiveRegressor\n",
+      "PatchExtractor\n",
+      "PolynomialCountSketch\n",
+      "PolynomialFeatures\n",
+      "PowerTransformer\n",
+      "QuadraticDiscriminantAnalysis\n",
+      "QuantileTransformer\n",
+      "RBFSampler\n",
+      "RFE\n",
+      "RFECV\n",
+      "RadiusNeighborsClassifier\n",
+      "RadiusNeighborsRegressor\n",
+      "RadiusNeighborsTransformer\n",
+      "RegressorChain\n",
+      "RobustScaler\n",
+      "SelectFdr\n",
+      "SelectFpr\n",
+      "SelectFromModel\n",
+      "SelectFwe\n",
+      "SelectKBest\n",
+      "SelectPercentile\n",
+      "SelfTrainingClassifier\n",
+      "SequentialFeatureSelector\n",
+      "SimpleImputer\n",
+      "SkewedChi2Sampler\n",
+      "SparseCoder\n",
+      "SparsePCA\n",
+      "SparseRandomProjection\n",
+      "SpectralClustering\n",
+      "TSNE\n",
+      "TargetEncoder\n",
+      "TfidfTransformer\n",
+      "TheilSenRegressor\n",
+      "TransformedTargetRegressor\n",
+      "TruncatedSVD\n",
+      "TunedThresholdClassifierCV\n",
+      "VarianceThreshold\n"
+     ]
+    }
+   ],
    "source": [
     "for est_name in missing_sample_weight_support:\n",
     "    print(est_name)"

--- a/src/sample_weight_audit/data.py
+++ b/src/sample_weight_audit/data.py
@@ -32,7 +32,7 @@ def weighted_and_repeated_train_test_split(
     )
     rng = np.random.default_rng(random_state)
     repeated_indices = np.repeat(np.arange(X_train.shape[0]), sample_weight_train)
-    shuffled_indices = rng.permutation(repeated_indices)
+    shuffled_indices = rng.permutation(len(repeated_indices))
     X_resampled_by_weights = np.take(X_train, repeated_indices, axis=0)[
         shuffled_indices
     ]

--- a/src/sample_weight_audit/data.py
+++ b/src/sample_weight_audit/data.py
@@ -32,14 +32,9 @@ def weighted_and_repeated_train_test_split(
     )
     rng = np.random.default_rng(random_state)
     repeated_indices = np.repeat(np.arange(X_train.shape[0]), sample_weight_train)
-    shuffled_indices = rng.permutation(len(repeated_indices))
-    X_resampled_by_weights = np.take(X_train, repeated_indices, axis=0)[
-        shuffled_indices
-    ]
-    y_resampled_by_weights = np.take(y_train, repeated_indices, axis=0)[
-        shuffled_indices
-    ]
-
+    shuffled_indices = rng.permutation(repeated_indices)
+    X_resampled_by_weights = np.take(X_train, shuffled_indices, axis=0)
+    y_resampled_by_weights = np.take(y_train, shuffled_indices, axis=0)
     return (
         X_train,
         y_train,

--- a/src/sample_weight_audit/data.py
+++ b/src/sample_weight_audit/data.py
@@ -30,11 +30,9 @@ def weighted_and_repeated_train_test_split(
             X, y, sample_weight, train_size=train_size, random_state=random_state
         )
     )
-    rng = np.random.default_rng(random_state)
     repeated_indices = np.repeat(np.arange(X_train.shape[0]), sample_weight_train)
-    shuffled_indices = rng.permutation(repeated_indices)
-    X_resampled_by_weights = np.take(X_train, shuffled_indices, axis=0)
-    y_resampled_by_weights = np.take(y_train, shuffled_indices, axis=0)
+    X_resampled_by_weights = np.take(X_train, repeated_indices, axis=0)
+    y_resampled_by_weights = np.take(y_train, repeated_indices, axis=0)
     return (
         X_train,
         y_train,

--- a/src/sample_weight_audit/data.py
+++ b/src/sample_weight_audit/data.py
@@ -30,9 +30,15 @@ def weighted_and_repeated_train_test_split(
             X, y, sample_weight, train_size=train_size, random_state=random_state
         )
     )
+    rng = np.random.default_rng(random_state)
     repeated_indices = np.repeat(np.arange(X_train.shape[0]), sample_weight_train)
-    X_resampled_by_weights = np.take(X_train, repeated_indices, axis=0)
-    y_resampled_by_weights = np.take(y_train, repeated_indices, axis=0)
+    shuffled_indices = rng.permutation(repeated_indices)
+    X_resampled_by_weights = np.take(X_train, repeated_indices, axis=0)[
+        shuffled_indices
+    ]
+    y_resampled_by_weights = np.take(y_train, repeated_indices, axis=0)[
+        shuffled_indices
+    ]
 
     return (
         X_train,

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -294,7 +294,11 @@ def multifit_over_weighted_and_repeated(
     predictions_repeated_all = []
     for seed in tqdm(range(n_stochastic_fits)):
         est_weighted = clone(est).set_params(random_state=seed, **extra_params_weighted)
-        est_repeated = clone(est).set_params(random_state=seed, **extra_params_repeated)
+        # Use different random seeds for the other group of fits to avoid
+        # introducing an unwanted statistical dependency.
+        est_repeated = clone(est).set_params(
+            random_state=seed + n_stochastic_fits, **extra_params_repeated
+        )
         est_weighted = check_pipeline_and_fit(
             est_weighted,
             X_train,

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import numpy as np
-from sklearn.base import clone, is_classifier, is_regressor, is_clusterer
+from sklearn.base import clone, is_classifier, is_regressor
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import LeaveOneGroupOut
@@ -179,7 +179,7 @@ def compute_predictions(est, X):
 
 
 def check_pipeline_and_fit(est, X, y, sample_weight=None, seed=None):
-    if not is_classifier(est) and not is_regressor(est) and not is_clusterer(est):
+    if not is_classifier(est) and not is_regressor(est) and hasattr(est, "transform"):
         est = Pipeline(
             [
                 ("transformer", est),

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import numpy as np
-from sklearn.base import clone, is_classifier, is_regressor
+from sklearn.base import clone, is_classifier, is_regressor, is_clusterer
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import LeaveOneGroupOut
@@ -179,7 +179,7 @@ def compute_predictions(est, X):
 
 
 def check_pipeline_and_fit(est, X, y, sample_weight=None, seed=None):
-    if not is_classifier(est) and not is_regressor(est) and hasattr(est, "transform"):
+    if not is_classifier(est) and not is_regressor(est) and not is_clusterer(est):
         est = Pipeline(
             [
                 ("transformer", est),

--- a/src/sample_weight_audit/sklearn_stochastic_params.py
+++ b/src/sample_weight_audit/sklearn_stochastic_params.py
@@ -1,6 +1,6 @@
 # List scikit-learn estimator param
 from sklearn.calibration import LinearSVC
-from sklearn.cluster import KMeans, MiniBatchKMeans
+from sklearn.cluster import BisectingKMeans, KMeans, MiniBatchKMeans
 from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import (
     ElasticNet,
@@ -37,6 +37,7 @@ STOCHASTIC_FIT_PARAMS = {
     AdaBoostRegressor: {
         "estimator": DecisionTreeRegressor(max_depth=1, max_features=0.5)
     },
+    BisectingKMeans: {"n_clusters": 10},
     LinearSVR: {"dual": True},
     LinearSVC: {"dual": True},
     Ridge: {"solver": "sag"},

--- a/src/sample_weight_audit/sklearn_stochastic_params.py
+++ b/src/sample_weight_audit/sklearn_stochastic_params.py
@@ -32,10 +32,14 @@ from sklearn.ensemble import GradientBoostingRegressor
 # Parametrizations of scikit-learn estimators that are known to make them stochastic.
 STOCHASTIC_FIT_PARAMS = {
     AdaBoostClassifier: {
-        "estimator": DecisionTreeClassifier(max_depth=1, max_features=0.5)
+        "estimator": DecisionTreeClassifier(
+            max_depth=1, max_features=0.5, class_weight="balanced"
+        )
     },
     AdaBoostRegressor: {
-        "estimator": DecisionTreeRegressor(max_depth=1, max_features=0.5)
+        "estimator": DecisionTreeRegressor(
+            max_depth=1, max_features=0.5, class_weight="balanced"
+        )
     },
     BisectingKMeans: {"n_clusters": 10},
     LinearSVR: {"dual": True},
@@ -45,6 +49,7 @@ STOCHASTIC_FIT_PARAMS = {
     LassoCV: {"selection": "random"},
     ElasticNet: {"selection": "random"},
     ElasticNetCV: {"selection": "random"},
+    DecisionTreeClassifier: {"max_features": 0.5, "class_weight": "balanced"},
     DecisionTreeRegressor: {"max_features": 0.5},
     GradientBoostingClassifier: {"max_features": 0.5},
     GradientBoostingRegressor: {"max_features": 0.5},
@@ -52,7 +57,6 @@ STOCHASTIC_FIT_PARAMS = {
     HistGradientBoostingClassifier: {"max_features": 0.5},
     KMeans: {"n_clusters": 10},
     RandomForestRegressor: {"max_features": 0.5},
-    DecisionTreeClassifier: {"max_features": 0.5},
     DummyClassifier: {"strategy": "stratified"},
     LogisticRegression: {
         "dual": True,

--- a/src/sample_weight_audit/sklearn_stochastic_params.py
+++ b/src/sample_weight_audit/sklearn_stochastic_params.py
@@ -32,20 +32,20 @@ from sklearn.ensemble import GradientBoostingRegressor
 # Parametrizations of scikit-learn estimators that are known to make them stochastic.
 STOCHASTIC_FIT_PARAMS = {
     AdaBoostClassifier: {
-        "estimator": DecisionTreeClassifier(max_features=0.5, min_samples_split=0.3)
+        "estimator": DecisionTreeClassifier(max_features=0.5, min_weight_fraction_leaf=0.1)
     },
     AdaBoostRegressor: {
-        "estimator": DecisionTreeRegressor(max_depth=1, max_features=0.5)
+        "estimator": DecisionTreeRegressor(max_features=0.5, min_weight_fraction_leaf=0.1)
     },
     BisectingKMeans: {"n_clusters": 10},
     LinearSVR: {"dual": True},
     LinearSVC: {"dual": True},
-    Ridge: {"solver": "sag"},
+    Ridge: {"solver": "sag", "max_iter": 100_000},
     Lasso: {"selection": "random"},
     LassoCV: {"selection": "random"},
     ElasticNet: {"selection": "random"},
     ElasticNetCV: {"selection": "random"},
-    DecisionTreeClassifier: {"max_features": 0.5, "min_samples_split": 0.3},
+    DecisionTreeClassifier: {"max_features": 0.5, "min_weight_fraction_leaf": 0.1},
     DecisionTreeRegressor: {"max_features": 0.5},
     GradientBoostingClassifier: {"max_features": 0.5},
     GradientBoostingRegressor: {"max_features": 0.5},
@@ -57,15 +57,15 @@ STOCHASTIC_FIT_PARAMS = {
     LogisticRegression: {
         "dual": True,
         "solver": "liblinear",
-        "max_iter": 10000,
+        "max_iter": 100_000,
     },
     LogisticRegressionCV: {
         "dual": True,
         "solver": "liblinear",
-        "max_iter": 10000,
+        "max_iter": 100_000,
     },
     NuSVC: {"probability": True},
-    RidgeClassifier: {"solver": "saga"},
+    RidgeClassifier: {"solver": "saga", "max_iter": 100_000},
     SVC: {"probability": True},
     KBinsDiscretizer: {
         "subsample": 50,
@@ -73,7 +73,7 @@ STOCHASTIC_FIT_PARAMS = {
         "strategy": "quantile",
         "quantile_method": "averaged_inverted_cdf",
     },
-    MiniBatchKMeans: {"n_clusters": 10, "reassignment_ratio": 0.9},
+    MiniBatchKMeans: {"n_clusters": 10, "reassignment_ratio": 0.01},
     RandomTreesEmbedding: {
         "n_estimators": 10,
     },

--- a/src/sample_weight_audit/sklearn_stochastic_params.py
+++ b/src/sample_weight_audit/sklearn_stochastic_params.py
@@ -6,12 +6,15 @@ from sklearn.linear_model import (
     ElasticNet,
     LogisticRegression,
     LogisticRegressionCV,
+    Perceptron,
     Ridge,
     RidgeClassifier,
 )
 from sklearn.linear_model import ElasticNetCV
 from sklearn.linear_model import Lasso
 from sklearn.linear_model import LassoCV
+from sklearn.linear_model import SGDClassifier
+from sklearn.linear_model import SGDRegressor
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.svm import SVC, LinearSVR, NuSVC
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
@@ -32,10 +35,14 @@ from sklearn.ensemble import GradientBoostingRegressor
 # Parametrizations of scikit-learn estimators that are known to make them stochastic.
 STOCHASTIC_FIT_PARAMS = {
     AdaBoostClassifier: {
-        "estimator": DecisionTreeClassifier(max_features=0.5, min_weight_fraction_leaf=0.1)
+        "estimator": DecisionTreeClassifier(
+            max_features=0.5, min_weight_fraction_leaf=0.1
+        )
     },
     AdaBoostRegressor: {
-        "estimator": DecisionTreeRegressor(max_features=0.5, min_weight_fraction_leaf=0.1)
+        "estimator": DecisionTreeRegressor(
+            max_features=0.5, min_weight_fraction_leaf=0.1
+        )
     },
     BisectingKMeans: {"n_clusters": 10},
     LinearSVR: {"dual": True},
@@ -60,8 +67,7 @@ STOCHASTIC_FIT_PARAMS = {
         "max_iter": 100_000,
     },
     LogisticRegressionCV: {
-        "dual": True,
-        "solver": "liblinear",
+        "solver": "saga",
         "max_iter": 100_000,
     },
     NuSVC: {"probability": True},
@@ -74,7 +80,8 @@ STOCHASTIC_FIT_PARAMS = {
         "quantile_method": "averaged_inverted_cdf",
     },
     MiniBatchKMeans: {"n_clusters": 10, "reassignment_ratio": 0.01},
-    RandomTreesEmbedding: {
-        "n_estimators": 10,
-    },
+    RandomTreesEmbedding: {"n_estimators": 10},
+    SGDClassifier: {"max_iter": 100_000},
+    SGDRegressor: {"max_iter": 100_000},
+    Perceptron: {"max_iter": 100_000},
 }

--- a/src/sample_weight_audit/sklearn_stochastic_params.py
+++ b/src/sample_weight_audit/sklearn_stochastic_params.py
@@ -37,9 +37,7 @@ STOCHASTIC_FIT_PARAMS = {
         )
     },
     AdaBoostRegressor: {
-        "estimator": DecisionTreeRegressor(
-            max_depth=1, max_features=0.5, class_weight="balanced"
-        )
+        "estimator": DecisionTreeRegressor(max_depth=1, max_features=0.5)
     },
     BisectingKMeans: {"n_clusters": 10},
     LinearSVR: {"dual": True},

--- a/src/sample_weight_audit/sklearn_stochastic_params.py
+++ b/src/sample_weight_audit/sklearn_stochastic_params.py
@@ -1,6 +1,6 @@
 # List scikit-learn estimator param
 from sklearn.calibration import LinearSVC
-from sklearn.cluster import MiniBatchKMeans
+from sklearn.cluster import KMeans, MiniBatchKMeans
 from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import (
     ElasticNet,
@@ -49,6 +49,7 @@ STOCHASTIC_FIT_PARAMS = {
     GradientBoostingRegressor: {"max_features": 0.5},
     HistGradientBoostingRegressor: {"max_features": 0.5},
     HistGradientBoostingClassifier: {"max_features": 0.5},
+    KMeans: {"n_clusters": 10},
     RandomForestRegressor: {"max_features": 0.5},
     DecisionTreeClassifier: {"max_features": 0.5},
     DummyClassifier: {"strategy": "stratified"},
@@ -69,8 +70,9 @@ STOCHASTIC_FIT_PARAMS = {
         "subsample": 50,
         "encode": "ordinal",
         "strategy": "quantile",
+        "quantile_method": "averaged_inverted_cdf",
     },
-    MiniBatchKMeans: {"reassignment_ratio": 0.9},
+    MiniBatchKMeans: {"n_clusters": 10, "reassignment_ratio": 0.9},
     RandomTreesEmbedding: {
         "n_estimators": 10,
     },

--- a/src/sample_weight_audit/sklearn_stochastic_params.py
+++ b/src/sample_weight_audit/sklearn_stochastic_params.py
@@ -32,9 +32,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 # Parametrizations of scikit-learn estimators that are known to make them stochastic.
 STOCHASTIC_FIT_PARAMS = {
     AdaBoostClassifier: {
-        "estimator": DecisionTreeClassifier(
-            max_depth=1, max_features=0.5, class_weight="balanced"
-        )
+        "estimator": DecisionTreeClassifier(max_features=0.5, min_samples_split=0.3)
     },
     AdaBoostRegressor: {
         "estimator": DecisionTreeRegressor(max_depth=1, max_features=0.5)
@@ -47,7 +45,7 @@ STOCHASTIC_FIT_PARAMS = {
     LassoCV: {"selection": "random"},
     ElasticNet: {"selection": "random"},
     ElasticNetCV: {"selection": "random"},
-    DecisionTreeClassifier: {"max_features": 0.5, "class_weight": "balanced"},
+    DecisionTreeClassifier: {"max_features": 0.5, "min_samples_split": 0.3},
     DecisionTreeRegressor: {"max_features": 0.5},
     GradientBoostingClassifier: {"max_features": 0.5},
     GradientBoostingRegressor: {"max_features": 0.5},


### PR DESCRIPTION
This PR addS shuffle indices and is_clusterer method as well as updates reports. Attempts to fix p-value behaviour under np.random.choice as identified by @jeremiedbb in issue #14 

TO DO:

- [ ] The test seems to still be unstable: some times 13 estimators pass, other times 17 estimators.
- [x] DecisionTreeClassifier was only sensitive when min_samples_split was changed otherwise predicitons are the same: this does not solve the p-value=1 problem for AdaBoostClassifier
- [ ] ExtraTreeClassifier (which has DecisionTreeClassifier at the back) is still having the problem where p-values are 1