### PR TITLE
Check scale-free weights property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sample-weight-audit-nondet"
 version = "2025.1.0"
 description = "Auditing tool for sample weight equivalence for non-deterministic estimators"
 readme = "README.md"
-maintainers = [{name = "Shruti Nath", email = "shruti@probabl.ai"},{name = "Olivier Grisel", email = "olivier@probabl.ai"}, {name = Jeremie du Boisberranger, email = jeremie@probabl.ai}]
+maintainers = [{name = "Shruti Nath", email = "shruti@probabl.ai"},{name = "Olivier Grisel", email = "olivier@probabl.ai"}, {name = "Jeremie du Boisberranger", email = "jeremie@probabl.ai"}]
 dependencies = ["numpy>=1.22", "scikit-learn>=1.6", "tqdm>=4.67"]
 requires-python = ">=3.9"
 

--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -20,30 +20,39 @@
      "text": [
       "\n",
       "System:\n",
-      "    python: 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]\n",
-      "executable: /Users/ogrisel/miniforge3/envs/dev/bin/python\n",
-      "   machine: macOS-15.2-arm64-arm-64bit\n",
+      "    python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:13:44) [Clang 16.0.6 ]\n",
+      "executable: /Users/shrutinath/micromamba/envs/scikit-learn/bin/python\n",
+      "   machine: macOS-14.3-arm64-arm-64bit\n",
       "\n",
       "Python dependencies:\n",
       "      sklearn: 1.7.dev0\n",
-      "          pip: 25.0\n",
+      "          pip: 24.0\n",
       "   setuptools: 75.8.0\n",
-      "        numpy: 2.1.3\n",
-      "        scipy: 1.15.1\n",
-      "       Cython: 3.0.11\n",
-      "       pandas: 2.2.3\n",
-      "   matplotlib: 3.10.0\n",
-      "       joblib: 1.5.dev0\n",
+      "        numpy: 2.0.0\n",
+      "        scipy: 1.14.0\n",
+      "       Cython: 3.0.10\n",
+      "       pandas: 2.2.2\n",
+      "   matplotlib: 3.9.0\n",
+      "       joblib: 1.4.2\n",
       "threadpoolctl: 3.5.0\n",
       "\n",
       "Built with OpenMP: True\n",
       "\n",
       "threadpoolctl info:\n",
+      "       user_api: blas\n",
+      "   internal_api: openblas\n",
+      "    num_threads: 8\n",
+      "         prefix: libopenblas\n",
+      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libopenblas.0.dylib\n",
+      "        version: 0.3.27\n",
+      "threading_layer: openmp\n",
+      "   architecture: VORTEX\n",
+      "\n",
       "       user_api: openmp\n",
       "   internal_api: openmp\n",
       "    num_threads: 8\n",
       "         prefix: libomp\n",
-      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libomp.dylib\n",
+      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libomp.dylib\n",
       "        version: None\n"
      ]
     }
@@ -70,6 +79,8 @@
     "from sklearn.preprocessing import KBinsDiscretizer\n",
     "import threadpoolctl\n",
     "\n",
+    "import sys\n",
+    "sys.path.insert(1,'../src/')\n",
     "from sample_weight_audit import check_weighted_repeated_estimator_fit_equivalence\n",
     "from sample_weight_audit.sklearn_stochastic_params import STOCHASTIC_FIT_PARAMS\n",
     "\n",
@@ -96,6 +107,51 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.utils._testing import  assert_allclose_dense_sparse,set_random_state\n",
+    "from sklearn.base import clone\n",
+    "import numpy as np\n",
+    "from sklearn.utils import shuffle\n",
+    "from sklearn.utils.estimator_checks import (\n",
+    "    _enforce_estimator_tags_y,\n",
+    ")\n",
+    "\n",
+    "def check_sample_weight_scaling(estimator_orig):\n",
+    "    # check that setting sample_weight to zero / integer is equivalent\n",
+    "    # to removing / repeating corresponding samples.\n",
+    "    estimator_1= clone(estimator_orig())\n",
+    "    estimator_2 = clone(estimator_orig())\n",
+    "    set_random_state(estimator_1, random_state=0)\n",
+    "    set_random_state(estimator_2, random_state=0)\n",
+    "\n",
+    "    rng = np.random.RandomState(42)\n",
+    "    n_samples = 15\n",
+    "    X = rng.rand(n_samples, n_samples * 2)\n",
+    "    y = rng.randint(0, 3, size=n_samples)\n",
+    "\n",
+    "    X, y = shuffle(X, y, random_state=0)\n",
+    "    y = _enforce_estimator_tags_y(estimator_1, y)\n",
+    "\n",
+    "    estimator_1.fit(X, y=y, sample_weight=1)\n",
+    "    estimator_2.fit(X, y=y, sample_weight=2)\n",
+    "\n",
+    "    for method in [\"predict_proba\", \"decision_function\", \"predict\", \"transform\"]:\n",
+    "        if hasattr(estimator_orig, method):\n",
+    "            X_pred1 = getattr(estimator_1, method)(X)\n",
+    "            X_pred2 = getattr(estimator_2, method)(X)\n",
+    "            err_msg = (\n",
+    "                f\"Comparing the output of {estimator_orig.__name__}.{method} revealed that fitting \"\n",
+    "                \"with `sample_weight` is not equivalent to fitting with\"\n",
+    "                \"`sample_weight*scaling_factor`.\"\n",
+    "            )\n",
+    "            assert_allclose_dense_sparse(X_pred1, X_pred2, err_msg=err_msg)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
    "outputs": [
@@ -112,14 +168,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 13.78it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 16.63it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostClassifier: (pvalue: 0.815)\n",
+      "✅ AdaBoostClassifier: (pvalue: 0.702)\n",
       "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_features=0.5,\n",
       "                                                  min_weight_fraction_leaf=0.1))\n"
      ]
@@ -128,14 +184,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:05<00:00, 16.71it/s]\n"
+      "100%|██████████| 100/100 [00:04<00:00, 20.93it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostRegressor: (pvalue: 0.155)\n",
+      "✅ AdaBoostRegressor: (pvalue: 0.036)\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -146,7 +202,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:04<00:00, 23.58it/s]\n"
+      "100%|██████████| 100/100 [00:03<00:00, 33.22it/s]\n"
      ]
     },
     {
@@ -161,7 +217,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 64.36it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 86.43it/s]\n"
      ]
     },
     {
@@ -176,7 +232,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 377.53it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 509.39it/s]\n"
      ]
     },
     {
@@ -191,7 +247,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 18.91it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 445.21it/s]\n"
      ]
     },
     {
@@ -209,7 +265,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 141.52it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 291.72it/s]\n"
      ]
     },
     {
@@ -225,7 +281,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 43.70it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 83.94it/s]\n"
      ]
     },
     {
@@ -243,7 +299,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 94.80it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 209.33it/s]\n"
      ]
     },
     {
@@ -260,7 +316,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 186.60it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 462.28it/s]\n"
      ]
     },
     {
@@ -275,7 +331,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 44.93it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 98.68it/s]\n"
      ]
     },
     {
@@ -290,14 +346,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 449.98it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 653.12it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeClassifier: (pvalue: 0.583)\n",
+      "✅ DecisionTreeClassifier: (pvalue: 0.702)\n",
       "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
      ]
     },
@@ -305,14 +361,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 660.18it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 881.15it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeRegressor: (pvalue: 0.282)\n",
+      "✅ DecisionTreeRegressor: (pvalue: 0.211)\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -322,7 +378,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 636.25it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 894.56it/s]\n"
      ]
     },
     {
@@ -337,7 +393,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 615.00it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 1626.33it/s]\n"
      ]
     },
     {
@@ -352,14 +408,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 529.92it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 941.77it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNet: (pvalue: 0.111)\n",
+      "✅ ElasticNet: (pvalue: 0.368)\n",
       "Evaluating ElasticNetCV(selection='random')\n"
      ]
     },
@@ -367,14 +423,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:02<00:00, 46.09it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 57.03it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNetCV: (pvalue: 0.282)\n",
+      "✅ ElasticNetCV: (pvalue: 0.470)\n",
       "Evaluating ExtraTreeClassifier()\n"
      ]
     },
@@ -382,14 +438,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 378.24it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 637.09it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeClassifier: (pvalue: 0.470)\n",
+      "✅ ExtraTreeClassifier: (pvalue: 0.815)\n",
       "Evaluating ExtraTreeRegressor()\n"
      ]
     },
@@ -397,14 +453,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 555.15it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 871.76it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeRegressor: (pvalue: 1.000)\n",
+      "✅ ExtraTreeRegressor: (pvalue: 0.282)\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -412,14 +468,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:09<00:00, 10.81it/s]\n"
+      "100%|██████████| 100/100 [00:07<00:00, 13.10it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreesClassifier: (pvalue: 0.815)\n",
+      "✅ ExtraTreesClassifier: (pvalue: 0.968)\n",
       "Evaluating ExtraTreesRegressor()\n"
      ]
     },
@@ -427,14 +483,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:08<00:00, 11.48it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 14.57it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreesRegressor: (pvalue: 0.000)\n",
+      "✅ ExtraTreesRegressor: (pvalue: 0.282)\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -449,7 +505,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 224.87it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 556.20it/s]\n"
      ]
     },
     {
@@ -464,7 +520,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 275.11it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 350.40it/s]\n"
      ]
     },
     {
@@ -483,14 +539,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:20<00:00,  4.78it/s]\n"
+      "100%|██████████| 100/100 [00:16<00:00,  6.05it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingClassifier: (pvalue: 0.155)\n",
+      "✅ GradientBoostingClassifier: (pvalue: 0.211)\n",
       "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -498,14 +554,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:04<00:00, 22.22it/s]\n"
+      "100%|██████████| 100/100 [00:03<00:00, 28.74it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingRegressor: (pvalue: 0.211)\n",
+      "✅ GradientBoostingRegressor: (pvalue: 0.111)\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -515,7 +571,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:51<00:00,  1.93it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 14.50it/s]\n"
      ]
     },
     {
@@ -530,7 +586,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:21<00:00,  4.76it/s]\n"
+      "100%|██████████| 100/100 [00:02<00:00, 35.22it/s]\n"
      ]
     },
     {
@@ -545,7 +601,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 45.56it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 56.41it/s]\n"
      ]
     },
     {
@@ -562,7 +618,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 31.11it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 821.61it/s]\n"
      ]
     },
     {
@@ -578,7 +634,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 274.83it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 370.12it/s]\n"
      ]
     },
     {
@@ -593,7 +649,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 294.86it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 460.65it/s]\n"
      ]
     },
     {
@@ -614,7 +670,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 330.60it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 564.36it/s]\n"
      ]
     },
     {
@@ -635,7 +691,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 481.89it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 934.27it/s]\n"
      ]
     },
     {
@@ -650,14 +706,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:02<00:00, 45.64it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 57.36it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ LassoCV: (pvalue: 0.368)\n",
+      "✅ LassoCV: (pvalue: 0.155)\n",
       "⚠ LassoLars does not support sample_weight\n",
       "⚠ LassoLarsCV does not support sample_weight\n",
       "⚠ LassoLarsIC does not support sample_weight\n",
@@ -670,7 +726,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 449.79it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 952.39it/s]\n"
      ]
     },
     {
@@ -685,7 +741,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 101.45it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 144.23it/s]\n"
      ]
     },
     {
@@ -700,7 +756,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 123.37it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 196.30it/s]\n"
      ]
     },
     {
@@ -716,7 +772,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 266.94it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 375.83it/s]\n"
      ]
     },
     {
@@ -732,14 +788,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 12.87it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 16.55it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ MLPClassifier: (pvalue: 0.211)\n",
+      "✅ MLPClassifier: (pvalue: 0.054)\n",
       "Evaluating MLPRegressor()\n"
      ]
     },
@@ -747,14 +803,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:06<00:00, 14.71it/s]\n"
+      "100%|██████████| 100/100 [00:05<00:00, 18.97it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ MLPRegressor: (pvalue: 0.583)\n",
+      "✅ MLPRegressor: (pvalue: 0.368)\n",
       "⚠ MaxAbsScaler does not support sample_weight\n",
       "⚠ MeanShift does not support sample_weight\n",
       "⚠ MinMaxScaler does not support sample_weight\n",
@@ -766,7 +822,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 110.52it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 273.87it/s]\n"
      ]
     },
     {
@@ -791,7 +847,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 259.00it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 492.58it/s]\n"
      ]
     },
     {
@@ -810,7 +866,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 90.96it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 116.74it/s]\n"
      ]
     },
     {
@@ -825,7 +881,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 177.78it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 268.68it/s]\n"
      ]
     },
     {
@@ -856,14 +912,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 212.98it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 235.57it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Perceptron: (pvalue: 0.016)\n",
+      "❌ Perceptron: (pvalue: 0.000)\n",
       "Evaluating PoissonRegressor()\n"
      ]
     },
@@ -871,7 +927,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 218.28it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 521.61it/s]\n"
      ]
     },
     {
@@ -890,7 +946,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 12.22it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 214.97it/s]\n"
      ]
     },
     {
@@ -906,7 +962,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  3%|▎         | 3/100 [00:00<00:04, 22.55it/s]\n"
+      "  3%|▎         | 3/100 [00:00<00:03, 29.02it/s]\n"
      ]
     },
     {
@@ -927,7 +983,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:11<00:00,  8.37it/s]\n"
+      "100%|██████████| 100/100 [00:09<00:00, 10.96it/s]\n"
      ]
     },
     {
@@ -942,7 +998,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:10<00:00,  9.20it/s]\n"
+      "100%|██████████| 100/100 [00:08<00:00, 11.73it/s]\n"
      ]
     },
     {
@@ -957,17 +1013,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 63.72it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 85.46it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ RandomTreesEmbedding: (pvalue: 0.470)\n",
+      "✅ RandomTreesEmbedding: (pvalue: 0.583)\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(max_iter=100000, solver='sag')\n",
-      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #943. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Evaluating RidgeCV()\n"
      ]
     },
@@ -975,7 +1031,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 76.56it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 102.00it/s]\n"
      ]
     },
     {
@@ -984,7 +1040,7 @@
      "text": [
       "✅ RidgeCV: (pvalue: 1.000)\n",
       "Evaluating RidgeClassifier(max_iter=100000, solver='saga')\n",
-      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #812. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Evaluating RidgeClassifierCV()\n"
      ]
     },
@@ -992,7 +1048,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 24.80it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 58.21it/s]\n"
      ]
     },
     {
@@ -1008,7 +1064,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 217.44it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 298.47it/s]\n"
      ]
     },
     {
@@ -1023,7 +1079,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 720.75it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 939.42it/s]\n"
      ]
     },
     {
@@ -1038,7 +1094,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 103.92it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 139.52it/s]\n"
      ]
     },
     {
@@ -1053,7 +1109,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 209.08it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 279.51it/s]\n"
      ]
     },
     {
@@ -1082,7 +1138,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 113.88it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 196.00it/s]\n"
      ]
     },
     {
@@ -1099,7 +1155,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 160.18it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 376.64it/s]\n"
      ]
     },
     {
@@ -1121,7 +1177,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 222.36it/s]"
+      "100%|██████████| 1/1 [00:00<00:00, 584.82it/s]"
      ]
     },
     {
@@ -1165,6 +1221,9 @@
     "        print(f\"⚠ {est_name} does not support sample_weight\")\n",
     "        missing_sample_weight_support.append(est_name)\n",
     "        continue\n",
+    "\n",
+    "    elif \"random_state\" not in signature(est_class().__init__).parameters:\n",
+    "        est = est_class(**STOCHASTIC_FIT_PARAMS.get(est_class, {}))\n",
     "\n",
     "    try:\n",
     "        if est_name == \"CategoricalNB\":\n",
@@ -1210,15 +1269,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ 45 passed the statistical test\n",
-      "❌ 14 failed the statistical test\n",
+      "✅ 44 passed the statistical test\n",
+      "❌ 15 failed the statistical test\n",
       "❌ 3 other errors\n",
       "⚠ 112 estimators lack sample_weight support\n"
      ]
@@ -1250,343 +1309,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "index",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "estimator_name",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "pvalue",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "deterministic_predictions",
-         "rawType": "bool",
-         "type": "boolean"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "4f137462-9cb0-4c2d-a3ee-8ba385f75f19",
-       "rows": [
-        [
-         "42",
-         "NuSVC",
-         "2.2087606931995054e-59",
-         "False"
-        ],
-        [
-         "48",
-         "RandomForestRegressor",
-         "2.2087606931995054e-59",
-         "False"
-        ],
-        [
-         "54",
-         "SVC",
-         "2.2087606931995054e-59",
-         "False"
-        ],
-        [
-         "47",
-         "RandomForestClassifier",
-         "4.417521386399011e-57",
-         "False"
-        ],
-        [
-         "2",
-         "BaggingClassifier",
-         "4.395433779467016e-55",
-         "False"
-        ],
-        [
-         "25",
-         "HistGradientBoostingClassifier",
-         "5.600644140061753e-50",
-         "False"
-        ],
-        [
-         "53",
-         "SGDRegressor",
-         "2.596277269141426e-44",
-         "False"
-        ],
-        [
-         "35",
-         "LinearSVC",
-         "6.314161651442317e-19",
-         "False"
-        ],
-        [
-         "26",
-         "HistGradientBoostingRegressor",
-         "2.7084430241713094e-18",
-         "False"
-        ],
-        [
-         "3",
-         "BaggingRegressor",
-         "4.528308394643339e-17",
-         "False"
-        ],
-        [
-         "36",
-         "LinearSVR",
-         "2.458151170682656e-15",
-         "False"
-        ],
-        [
-         "37",
-         "LogisticRegression",
-         "3.751914289152195e-06",
-         "False"
-        ],
-        [
-         "52",
-         "SGDClassifier",
-         "7.850159128072286e-06",
-         "False"
-        ],
-        [
-         "20",
-         "ExtraTreesRegressor",
-         "3.211428734211389e-05",
-         "False"
-        ],
-        [
-         "44",
-         "Perceptron",
-         "0.015577131622877688",
-         "False"
-        ],
-        [
-         "15",
-         "ElasticNet",
-         "0.11119526053829192",
-         "False"
-        ],
-        [
-         "13",
-         "DummyClassifier",
-         "0.1548386665118475",
-         "False"
-        ],
-        [
-         "1",
-         "AdaBoostRegressor",
-         "0.1548386665118475",
-         "False"
-        ],
-        [
-         "23",
-         "GradientBoostingClassifier",
-         "0.1548386665118475",
-         "False"
-        ],
-        [
-         "24",
-         "GradientBoostingRegressor",
-         "0.21117008625127576",
-         "False"
-        ],
-        [
-         "38",
-         "MLPClassifier",
-         "0.21117008625127576",
-         "False"
-        ],
-        [
-         "12",
-         "DecisionTreeRegressor",
-         "0.2819416298082479",
-         "False"
-        ],
-        [
-         "16",
-         "ElasticNetCV",
-         "0.2819416298082479",
-         "False"
-        ],
-        [
-         "33",
-         "LassoCV",
-         "0.36818778606286096",
-         "False"
-        ],
-        [
-         "17",
-         "ExtraTreeClassifier",
-         "0.469506448503778",
-         "False"
-        ],
-        [
-         "49",
-         "RandomTreesEmbedding",
-         "0.469506448503778",
-         "False"
-        ],
-        [
-         "11",
-         "DecisionTreeClassifier",
-         "0.5830090612540064",
-         "False"
-        ],
-        [
-         "39",
-         "MLPRegressor",
-         "0.5830090612540064",
-         "False"
-        ],
-        [
-         "0",
-         "AdaBoostClassifier",
-         "0.8154147124661313",
-         "False"
-        ],
-        [
-         "29",
-         "KBinsDiscretizer",
-         "0.8154147124661313",
-         "False"
-        ],
-        [
-         "19",
-         "ExtraTreesClassifier",
-         "0.8154147124661313",
-         "False"
-        ],
-        [
-         "18",
-         "ExtraTreeRegressor",
-         "0.9996892272702655",
-         "False"
-        ],
-        [
-         "30",
-         "KMeans",
-         "1.0",
-         "False"
-        ],
-        [
-         "56",
-         "SplineTransformer",
-         "1.0",
-         "True"
-        ],
-        [
-         "55",
-         "SVR",
-         "1.0",
-         "True"
-        ],
-        [
-         "4",
-         "BayesianRidge",
-         "1.0",
-         "True"
-        ],
-        [
-         "5",
-         "BernoulliNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "6",
-         "BisectingKMeans",
-         "1.0",
-         "False"
-        ],
-        [
-         "51",
-         "RidgeClassifierCV",
-         "1.0",
-         "True"
-        ],
-        [
-         "50",
-         "RidgeCV",
-         "1.0",
-         "True"
-        ],
-        [
-         "7",
-         "CalibratedClassifierCV",
-         "1.0",
-         "True"
-        ],
-        [
-         "8",
-         "CategoricalNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "9",
-         "ComplementNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "46",
-         "QuantileRegressor",
-         "1.0",
-         "True"
-        ],
-        [
-         "45",
-         "PoissonRegressor",
-         "1.0",
-         "True"
-        ],
-        [
-         "10",
-         "DBSCAN",
-         "1.0",
-         "False"
-        ],
-        [
-         "43",
-         "NuSVR",
-         "1.0",
-         "True"
-        ],
-        [
-         "14",
-         "DummyRegressor",
-         "1.0",
-         "True"
-        ],
-        [
-         "41",
-         "MultinomialNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "40",
-         "MiniBatchKMeans",
-         "1.0",
-         "False"
-        ]
-       ],
-       "shape": {
-        "columns": 3,
-        "rows": 59
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1613,14 +1340,20 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>42</th>\n",
+       "      <th>41</th>\n",
        "      <td>NuSVC</td>\n",
        "      <td>2.208761e-59</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>48</th>\n",
+       "      <th>47</th>\n",
        "      <td>RandomForestRegressor</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>Ridge</td>\n",
        "      <td>2.208761e-59</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
@@ -1631,7 +1364,7 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>47</th>\n",
+       "      <th>46</th>\n",
        "      <td>RandomForestClassifier</td>\n",
        "      <td>4.417521e-57</td>\n",
        "      <td>False</td>\n",
@@ -1645,66 +1378,72 @@
        "    <tr>\n",
        "      <th>25</th>\n",
        "      <td>HistGradientBoostingClassifier</td>\n",
-       "      <td>5.600644e-50</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>53</th>\n",
-       "      <td>SGDRegressor</td>\n",
-       "      <td>2.596277e-44</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>35</th>\n",
-       "      <td>LinearSVC</td>\n",
-       "      <td>6.314162e-19</td>\n",
+       "      <td>2.900986e-53</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>26</th>\n",
        "      <td>HistGradientBoostingRegressor</td>\n",
-       "      <td>2.708443e-18</td>\n",
+       "      <td>3.231288e-37</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>SGDRegressor</td>\n",
+       "      <td>4.111260e-34</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>BaggingRegressor</td>\n",
-       "      <td>4.528308e-17</td>\n",
+       "      <td>3.357101e-13</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36</th>\n",
-       "      <td>LinearSVR</td>\n",
-       "      <td>2.458151e-15</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>37</th>\n",
-       "      <td>LogisticRegression</td>\n",
-       "      <td>3.751914e-06</td>\n",
+       "      <th>34</th>\n",
+       "      <td>LinearSVC</td>\n",
+       "      <td>8.448372e-11</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>52</th>\n",
        "      <td>SGDClassifier</td>\n",
-       "      <td>7.850159e-06</td>\n",
+       "      <td>1.704797e-09</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>3.211429e-05</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>44</th>\n",
+       "      <th>43</th>\n",
        "      <td>Perceptron</td>\n",
-       "      <td>1.557713e-02</td>\n",
+       "      <td>1.115168e-08</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>ElasticNet</td>\n",
+       "      <th>36</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>8.001544e-07</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>LinearSVR</td>\n",
+       "      <td>6.281177e-05</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AdaBoostRegressor</td>\n",
+       "      <td>3.638429e-02</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>37</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>5.390208e-02</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
        "      <td>1.111953e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
@@ -1715,79 +1454,79 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>AdaBoostRegressor</td>\n",
+       "      <th>32</th>\n",
+       "      <td>LassoCV</td>\n",
        "      <td>1.548387e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>23</th>\n",
        "      <td>GradientBoostingClassifier</td>\n",
-       "      <td>1.548387e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>2.111701e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38</th>\n",
-       "      <td>MLPClassifier</td>\n",
        "      <td>2.111701e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
        "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>2.111701e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
        "      <td>2.819416e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
+       "      <td>2.819416e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>3.681878e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>3.681878e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
        "      <td>ElasticNetCV</td>\n",
-       "      <td>2.819416e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>33</th>\n",
-       "      <td>LassoCV</td>\n",
-       "      <td>3.681878e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>ExtraTreeClassifier</td>\n",
        "      <td>4.695064e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>49</th>\n",
+       "      <th>48</th>\n",
        "      <td>RandomTreesEmbedding</td>\n",
-       "      <td>4.695064e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>5.830091e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>39</th>\n",
-       "      <td>MLPRegressor</td>\n",
        "      <td>5.830091e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>AdaBoostClassifier</td>\n",
+       "      <td>7.020570e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
+       "      <td>7.020570e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>ExtraTreeClassifier</td>\n",
        "      <td>8.154147e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>29</th>\n",
+       "      <th>28</th>\n",
        "      <td>KBinsDiscretizer</td>\n",
        "      <td>8.154147e-01</td>\n",
        "      <td>False</td>\n",
@@ -1795,24 +1534,36 @@
        "    <tr>\n",
        "      <th>19</th>\n",
        "      <td>ExtraTreesClassifier</td>\n",
-       "      <td>8.154147e-01</td>\n",
+       "      <td>9.684099e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>9.996892e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>KMeans</td>\n",
+       "      <th>45</th>\n",
+       "      <td>QuantileRegressor</td>\n",
        "      <td>1.000000e+00</td>\n",
-       "      <td>False</td>\n",
+       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>56</th>\n",
-       "      <td>SplineTransformer</td>\n",
+       "      <th>44</th>\n",
+       "      <td>PoissonRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>42</th>\n",
+       "      <td>NuSVR</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50</th>\n",
+       "      <td>RidgeCV</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51</th>\n",
+       "      <td>RidgeClassifierCV</td>\n",
        "      <td>1.000000e+00</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
@@ -1821,6 +1572,24 @@
        "      <td>SVR</td>\n",
        "      <td>1.000000e+00</td>\n",
        "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>56</th>\n",
+       "      <td>SplineTransformer</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>KMeans</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
+       "      <td>MiniBatchKMeans</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1841,18 +1610,6 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>51</th>\n",
-       "      <td>RidgeClassifierCV</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>50</th>\n",
-       "      <td>RidgeCV</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>CalibratedClassifierCV</td>\n",
        "      <td>1.000000e+00</td>\n",
@@ -1871,46 +1628,16 @@
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>46</th>\n",
-       "      <td>QuantileRegressor</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>45</th>\n",
-       "      <td>PoissonRegressor</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>DBSCAN</td>\n",
        "      <td>1.000000e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>43</th>\n",
-       "      <td>NuSVR</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>DummyRegressor</td>\n",
        "      <td>1.000000e+00</td>\n",
        "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>41</th>\n",
-       "      <td>MultinomialNB</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>40</th>\n",
-       "      <td>MiniBatchKMeans</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>21</th>\n",
@@ -1931,32 +1658,32 @@
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>34</th>\n",
-       "      <td>LinearRegression</td>\n",
+       "      <th>57</th>\n",
+       "      <td>StandardScaler</td>\n",
        "      <td>1.000000e+00</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>IsotonicRegression</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>32</th>\n",
-       "      <td>Lasso</td>\n",
-       "      <td>1.000000e+00</td>\n",
-       "      <td>True</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31</th>\n",
+       "      <th>30</th>\n",
        "      <td>KernelRidge</td>\n",
        "      <td>1.000000e+00</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>57</th>\n",
-       "      <td>StandardScaler</td>\n",
+       "      <th>31</th>\n",
+       "      <td>Lasso</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>LinearRegression</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>40</th>\n",
+       "      <td>MultinomialNB</td>\n",
        "      <td>1.000000e+00</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
@@ -1972,68 +1699,68 @@
       ],
       "text/plain": [
        "                    estimator_name        pvalue  deterministic_predictions\n",
-       "42                           NuSVC  2.208761e-59                      False\n",
-       "48           RandomForestRegressor  2.208761e-59                      False\n",
+       "41                           NuSVC  2.208761e-59                      False\n",
+       "47           RandomForestRegressor  2.208761e-59                      False\n",
+       "49                           Ridge  2.208761e-59                      False\n",
        "54                             SVC  2.208761e-59                      False\n",
-       "47          RandomForestClassifier  4.417521e-57                      False\n",
+       "46          RandomForestClassifier  4.417521e-57                      False\n",
        "2                BaggingClassifier  4.395434e-55                      False\n",
-       "25  HistGradientBoostingClassifier  5.600644e-50                      False\n",
-       "53                    SGDRegressor  2.596277e-44                      False\n",
-       "35                       LinearSVC  6.314162e-19                      False\n",
-       "26   HistGradientBoostingRegressor  2.708443e-18                      False\n",
-       "3                 BaggingRegressor  4.528308e-17                      False\n",
-       "36                       LinearSVR  2.458151e-15                      False\n",
-       "37              LogisticRegression  3.751914e-06                      False\n",
-       "52                   SGDClassifier  7.850159e-06                      False\n",
-       "20             ExtraTreesRegressor  3.211429e-05                      False\n",
-       "44                      Perceptron  1.557713e-02                      False\n",
-       "15                      ElasticNet  1.111953e-01                      False\n",
+       "25  HistGradientBoostingClassifier  2.900986e-53                      False\n",
+       "26   HistGradientBoostingRegressor  3.231288e-37                      False\n",
+       "53                    SGDRegressor  4.111260e-34                      False\n",
+       "3                 BaggingRegressor  3.357101e-13                      False\n",
+       "34                       LinearSVC  8.448372e-11                      False\n",
+       "52                   SGDClassifier  1.704797e-09                      False\n",
+       "43                      Perceptron  1.115168e-08                      False\n",
+       "36              LogisticRegression  8.001544e-07                      False\n",
+       "35                       LinearSVR  6.281177e-05                      False\n",
+       "1                AdaBoostRegressor  3.638429e-02                      False\n",
+       "37                   MLPClassifier  5.390208e-02                      False\n",
+       "24       GradientBoostingRegressor  1.111953e-01                      False\n",
        "13                 DummyClassifier  1.548387e-01                      False\n",
-       "1                AdaBoostRegressor  1.548387e-01                      False\n",
-       "23      GradientBoostingClassifier  1.548387e-01                      False\n",
-       "24       GradientBoostingRegressor  2.111701e-01                      False\n",
-       "38                   MLPClassifier  2.111701e-01                      False\n",
-       "12           DecisionTreeRegressor  2.819416e-01                      False\n",
-       "16                    ElasticNetCV  2.819416e-01                      False\n",
-       "33                         LassoCV  3.681878e-01                      False\n",
-       "17             ExtraTreeClassifier  4.695064e-01                      False\n",
-       "49            RandomTreesEmbedding  4.695064e-01                      False\n",
-       "11          DecisionTreeClassifier  5.830091e-01                      False\n",
-       "39                    MLPRegressor  5.830091e-01                      False\n",
-       "0               AdaBoostClassifier  8.154147e-01                      False\n",
-       "29                KBinsDiscretizer  8.154147e-01                      False\n",
-       "19            ExtraTreesClassifier  8.154147e-01                      False\n",
-       "18              ExtraTreeRegressor  9.996892e-01                      False\n",
-       "30                          KMeans  1.000000e+00                      False\n",
-       "56               SplineTransformer  1.000000e+00                       True\n",
+       "32                         LassoCV  1.548387e-01                      False\n",
+       "23      GradientBoostingClassifier  2.111701e-01                      False\n",
+       "12           DecisionTreeRegressor  2.111701e-01                      False\n",
+       "20             ExtraTreesRegressor  2.819416e-01                      False\n",
+       "18              ExtraTreeRegressor  2.819416e-01                      False\n",
+       "38                    MLPRegressor  3.681878e-01                      False\n",
+       "15                      ElasticNet  3.681878e-01                      False\n",
+       "16                    ElasticNetCV  4.695064e-01                      False\n",
+       "48            RandomTreesEmbedding  5.830091e-01                      False\n",
+       "0               AdaBoostClassifier  7.020570e-01                      False\n",
+       "11          DecisionTreeClassifier  7.020570e-01                      False\n",
+       "17             ExtraTreeClassifier  8.154147e-01                      False\n",
+       "28                KBinsDiscretizer  8.154147e-01                      False\n",
+       "19            ExtraTreesClassifier  9.684099e-01                      False\n",
+       "45               QuantileRegressor  1.000000e+00                       True\n",
+       "44                PoissonRegressor  1.000000e+00                       True\n",
+       "42                           NuSVR  1.000000e+00                       True\n",
+       "50                         RidgeCV  1.000000e+00                       True\n",
+       "51               RidgeClassifierCV  1.000000e+00                       True\n",
        "55                             SVR  1.000000e+00                       True\n",
+       "56               SplineTransformer  1.000000e+00                       True\n",
+       "29                          KMeans  1.000000e+00                      False\n",
+       "39                 MiniBatchKMeans  1.000000e+00                      False\n",
        "4                    BayesianRidge  1.000000e+00                       True\n",
        "5                      BernoulliNB  1.000000e+00                       True\n",
        "6                  BisectingKMeans  1.000000e+00                      False\n",
-       "51               RidgeClassifierCV  1.000000e+00                       True\n",
-       "50                         RidgeCV  1.000000e+00                       True\n",
        "7           CalibratedClassifierCV  1.000000e+00                       True\n",
        "8                    CategoricalNB  1.000000e+00                       True\n",
        "9                     ComplementNB  1.000000e+00                       True\n",
-       "46               QuantileRegressor  1.000000e+00                       True\n",
-       "45                PoissonRegressor  1.000000e+00                       True\n",
        "10                          DBSCAN  1.000000e+00                      False\n",
-       "43                           NuSVR  1.000000e+00                       True\n",
        "14                  DummyRegressor  1.000000e+00                       True\n",
-       "41                   MultinomialNB  1.000000e+00                       True\n",
-       "40                 MiniBatchKMeans  1.000000e+00                      False\n",
        "21                  GammaRegressor  1.000000e+00                       True\n",
        "22                      GaussianNB  1.000000e+00                       True\n",
        "27                  HuberRegressor  1.000000e+00                       True\n",
-       "34                LinearRegression  1.000000e+00                       True\n",
-       "28              IsotonicRegression  1.000000e+00                       True\n",
-       "32                           Lasso  1.000000e+00                       True\n",
-       "31                     KernelRidge  1.000000e+00                       True\n",
        "57                  StandardScaler  1.000000e+00                       True\n",
+       "30                     KernelRidge  1.000000e+00                       True\n",
+       "31                           Lasso  1.000000e+00                       True\n",
+       "33                LinearRegression  1.000000e+00                       True\n",
+       "40                   MultinomialNB  1.000000e+00                       True\n",
        "58                TweedieRegressor  1.000000e+00                       True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2051,110 +1778,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
+      "❌ IsotonicRegression(): too many indices for array: array is 1-dimensional, but 2 were indexed\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "  File \"/var/folders/h4/l_wtcs4s43j2j9454pvp1c580000gn/T/ipykernel_94798/2504969921.py\", line 49, in <module>\n",
       "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
       "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 177, in check_weighted_repeated_estimator_fit_equivalence\n",
       "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 312, in multifit_over_weighted_and_repeated\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 473, in multifit_over_weighted_and_repeated\n",
+      "    X_train = _enforce_estimator_tags_X(est, X_train)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/estimator_checks.py\", line 3986, in _enforce_estimator_tags_X\n",
+      "    X = X[:, 0]\n",
+      "        ~^^^^^^\n",
+      "IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed\n",
+      "\n",
+      "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/h4/l_wtcs4s43j2j9454pvp1c580000gn/T/ipykernel_94798/2504969921.py\", line 49, in <module>\n",
+      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 177, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "    multifit_over_weighted_and_repeated(\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 520, in multifit_over_weighted_and_repeated\n",
       "    est_weighted = check_pipeline_and_fit(\n",
       "                   ^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 311, in check_pipeline_and_fit\n",
       "    est = est.fit(X, y, sample_weight=sample_weight)\n",
       "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
       "    return f(*args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
       "    estimator.fit(X_subset, y_subset, **fit_params_subset)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
       "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
       "                                        ^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
       "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
       "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 598, in _average\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/_array_api.py\", line 717, in _average\n",
       "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
       "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 575, in average\n",
+      "  File \"/Users/shrutinath/micromamba/envs/scikit-learn/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 570, in average\n",
       "    raise ZeroDivisionError(\n",
       "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
       "\n",
-      "❌ Ridge(max_iter=100000, solver='sag'): Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ RidgeClassifier(max_iter=800, solver='saga'): Input contains infinity or a value too large for dtype('float64').\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "  File \"/var/folders/h4/l_wtcs4s43j2j9454pvp1c580000gn/T/ipykernel_94798/2504969921.py\", line 49, in <module>\n",
       "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
       "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 177, in check_weighted_repeated_estimator_fit_equivalence\n",
       "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
-      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
-      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
-      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1249, in fit\n",
-      "    return super().fit(X, y, sample_weight=sample_weight)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
-      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
-      "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
-      "    coef_, n_iter_, _ = sag_solver(\n",
-      "                        ^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
-      "    num_seen, n_iter_ = sag(\n",
-      "                        ^^^^\n",
-      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
-      "\n",
-      "❌ RidgeClassifier(max_iter=100000, solver='saga'): Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
-      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
-      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
-      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
-      "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1571, in fit\n",
-      "    super().fit(X, Y, sample_weight=sample_weight)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
-      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
-      "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
-      "    coef_, n_iter_, _ = sag_solver(\n",
-      "                        ^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
-      "    num_seen, n_iter_ = sag(\n",
-      "                        ^^^^\n",
-      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 534, in multifit_over_weighted_and_repeated\n",
+      "    scores_weighted, preds_weighted = score_estimator(\n",
+      "                                      ^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 270, in score_estimator\n",
+      "    return average_precision_score(y, preds), preds\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/_param_validation.py\", line 218, in wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/metrics/_ranking.py\", line 263, in average_precision_score\n",
+      "    return _average_binary_score(\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/metrics/_base.py\", line 73, in _average_binary_score\n",
+      "    y_score = check_array(y_score)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/validation.py\", line 1105, in check_array\n",
+      "    _assert_all_finite(\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/validation.py\", line 120, in _assert_all_finite\n",
+      "    _assert_all_finite_element_wise(\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/validation.py\", line 169, in _assert_all_finite_element_wise\n",
+      "    raise ValueError(msg_err)\n",
+      "ValueError: Input contains infinity or a value too large for dtype('float64').\n",
       "\n"
      ]
     }

--- a/reports/sklearn_estimators_sample_weight_scaling_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_scaling_audit_report.ipynb
@@ -20,30 +20,39 @@
      "text": [
       "\n",
       "System:\n",
-      "    python: 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]\n",
-      "executable: /Users/ogrisel/miniforge3/envs/dev/bin/python\n",
-      "   machine: macOS-15.2-arm64-arm-64bit\n",
+      "    python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:13:44) [Clang 16.0.6 ]\n",
+      "executable: /Users/shrutinath/micromamba/envs/scikit-learn/bin/python\n",
+      "   machine: macOS-14.3-arm64-arm-64bit\n",
       "\n",
       "Python dependencies:\n",
       "      sklearn: 1.7.dev0\n",
-      "          pip: 25.0\n",
+      "          pip: 24.0\n",
       "   setuptools: 75.8.0\n",
-      "        numpy: 2.1.3\n",
-      "        scipy: 1.15.1\n",
-      "       Cython: 3.0.11\n",
-      "       pandas: 2.2.3\n",
-      "   matplotlib: 3.10.0\n",
-      "       joblib: 1.5.dev0\n",
+      "        numpy: 2.0.0\n",
+      "        scipy: 1.14.0\n",
+      "       Cython: 3.0.10\n",
+      "       pandas: 2.2.2\n",
+      "   matplotlib: 3.9.0\n",
+      "       joblib: 1.4.2\n",
       "threadpoolctl: 3.5.0\n",
       "\n",
       "Built with OpenMP: True\n",
       "\n",
       "threadpoolctl info:\n",
+      "       user_api: blas\n",
+      "   internal_api: openblas\n",
+      "    num_threads: 8\n",
+      "         prefix: libopenblas\n",
+      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libopenblas.0.dylib\n",
+      "        version: 0.3.27\n",
+      "threading_layer: openmp\n",
+      "   architecture: VORTEX\n",
+      "\n",
       "       user_api: openmp\n",
       "   internal_api: openmp\n",
       "    num_threads: 8\n",
       "         prefix: libomp\n",
-      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libomp.dylib\n",
+      "       filepath: /Users/shrutinath/micromamba/envs/scikit-learn/lib/libomp.dylib\n",
       "        version: None\n"
      ]
     }
@@ -56,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +79,9 @@
     "from sklearn.preprocessing import KBinsDiscretizer\n",
     "import threadpoolctl\n",
     "\n",
-    "from sample_weight_audit import check_weighted_repeated_estimator_fit_equivalence\n",
+    "import sys\n",
+    "sys.path.insert(1,'../src')\n",
+    "from sample_weight_audit import check_scale_free_equivalence\n",
     "from sample_weight_audit.sklearn_stochastic_params import STOCHASTIC_FIT_PARAMS\n",
     "\n",
     "# HistGradientBoostingClassifier trashes the OpenMP thread pool on repeated\n",
@@ -83,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -112,14 +123,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 13.78it/s]\n"
+      "100%|██████████| 100/100 [00:05<00:00, 17.21it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostClassifier: (pvalue: 0.815)\n",
+      "✅ AdaBoostClassifier: (pvalue: 0.702)\n",
       "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_features=0.5,\n",
       "                                                  min_weight_fraction_leaf=0.1))\n"
      ]
@@ -128,14 +139,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:05<00:00, 16.71it/s]\n"
+      "100%|██████████| 100/100 [00:04<00:00, 20.46it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostRegressor: (pvalue: 0.155)\n",
+      "✅ AdaBoostRegressor: (pvalue: 0.036)\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -146,7 +157,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:04<00:00, 23.58it/s]\n"
+      "100%|██████████| 100/100 [00:03<00:00, 31.08it/s]\n"
      ]
     },
     {
@@ -161,7 +172,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 64.36it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 82.58it/s]\n"
      ]
     },
     {
@@ -176,7 +187,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 377.53it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 805.98it/s]\n"
      ]
     },
     {
@@ -191,7 +202,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 18.91it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 325.42it/s]\n"
      ]
     },
     {
@@ -209,7 +220,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 141.52it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 219.77it/s]\n"
      ]
     },
     {
@@ -225,7 +236,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 43.70it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 74.41it/s]\n"
      ]
     },
     {
@@ -243,7 +254,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 94.80it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 130.96it/s]\n"
      ]
     },
     {
@@ -260,7 +271,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 186.60it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 463.15it/s]\n"
      ]
     },
     {
@@ -275,7 +286,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 44.93it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 81.17it/s]\n"
      ]
     },
     {
@@ -290,14 +301,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 449.98it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 630.26it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeClassifier: (pvalue: 0.583)\n",
+      "✅ DecisionTreeClassifier: (pvalue: 0.702)\n",
       "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
      ]
     },
@@ -305,14 +316,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 660.18it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 828.43it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ DecisionTreeRegressor: (pvalue: 0.282)\n",
+      "✅ DecisionTreeRegressor: (pvalue: 0.211)\n",
       "⚠ DictVectorizer does not support sample_weight\n",
       "⚠ DictionaryLearning does not support sample_weight\n",
       "Evaluating DummyClassifier(strategy='stratified')\n"
@@ -322,7 +333,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 636.25it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 855.12it/s]\n"
      ]
     },
     {
@@ -337,7 +348,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 615.00it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 1402.31it/s]\n"
      ]
     },
     {
@@ -352,14 +363,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 529.92it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 917.71it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNet: (pvalue: 0.111)\n",
+      "✅ ElasticNet: (pvalue: 0.368)\n",
       "Evaluating ElasticNetCV(selection='random')\n"
      ]
     },
@@ -367,14 +378,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:02<00:00, 46.09it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 55.25it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ElasticNetCV: (pvalue: 0.282)\n",
+      "✅ ElasticNetCV: (pvalue: 0.470)\n",
       "Evaluating ExtraTreeClassifier()\n"
      ]
     },
@@ -382,14 +393,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 378.24it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 611.86it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeClassifier: (pvalue: 0.470)\n",
+      "✅ ExtraTreeClassifier: (pvalue: 0.815)\n",
       "Evaluating ExtraTreeRegressor()\n"
      ]
     },
@@ -397,14 +408,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 555.15it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 867.65it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeRegressor: (pvalue: 1.000)\n",
+      "✅ ExtraTreeRegressor: (pvalue: 0.282)\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -412,14 +423,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:09<00:00, 10.81it/s]\n"
+      "100%|██████████| 100/100 [00:07<00:00, 13.66it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreesClassifier: (pvalue: 0.815)\n",
+      "✅ ExtraTreesClassifier: (pvalue: 0.968)\n",
       "Evaluating ExtraTreesRegressor()\n"
      ]
     },
@@ -427,14 +438,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:08<00:00, 11.48it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 14.47it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ ExtraTreesRegressor: (pvalue: 0.000)\n",
+      "✅ ExtraTreesRegressor: (pvalue: 0.282)\n",
       "⚠ FactorAnalysis does not support sample_weight\n",
       "⚠ FastICA does not support sample_weight\n",
       "⚠ FeatureAgglomeration does not support sample_weight\n",
@@ -449,7 +460,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 224.87it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 485.23it/s]\n"
      ]
     },
     {
@@ -464,7 +475,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 275.11it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 280.97it/s]\n"
      ]
     },
     {
@@ -483,14 +494,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:20<00:00,  4.78it/s]\n"
+      "100%|██████████| 100/100 [00:17<00:00,  5.72it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingClassifier: (pvalue: 0.155)\n",
+      "✅ GradientBoostingClassifier: (pvalue: 0.211)\n",
       "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
      ]
     },
@@ -498,14 +509,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:04<00:00, 22.22it/s]\n"
+      "100%|██████████| 100/100 [00:03<00:00, 26.75it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingRegressor: (pvalue: 0.211)\n",
+      "✅ GradientBoostingRegressor: (pvalue: 0.111)\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -515,7 +526,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:51<00:00,  1.93it/s]\n"
+      "100%|██████████| 100/100 [00:07<00:00, 13.84it/s]\n"
      ]
     },
     {
@@ -530,7 +541,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:21<00:00,  4.76it/s]\n"
+      "100%|██████████| 100/100 [00:02<00:00, 38.70it/s]\n"
      ]
     },
     {
@@ -545,7 +556,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 45.56it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 36.68it/s]\n"
      ]
     },
     {
@@ -562,7 +573,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 31.11it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 796.64it/s]\n"
      ]
     },
     {
@@ -578,7 +589,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 274.83it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 338.16it/s]\n"
      ]
     },
     {
@@ -593,7 +604,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 294.86it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 458.76it/s]\n"
      ]
     },
     {
@@ -614,7 +625,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 330.60it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 533.83it/s]\n"
      ]
     },
     {
@@ -635,7 +646,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 481.89it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 930.23it/s]\n"
      ]
     },
     {
@@ -650,14 +661,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:02<00:00, 45.64it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 56.35it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ LassoCV: (pvalue: 0.368)\n",
+      "✅ LassoCV: (pvalue: 0.155)\n",
       "⚠ LassoLars does not support sample_weight\n",
       "⚠ LassoLarsCV does not support sample_weight\n",
       "⚠ LassoLarsIC does not support sample_weight\n",
@@ -670,7 +681,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 449.79it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 1063.73it/s]\n"
      ]
     },
     {
@@ -685,7 +696,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 101.45it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 92.40it/s]\n"
      ]
     },
     {
@@ -700,7 +711,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 123.37it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 178.75it/s]\n"
      ]
     },
     {
@@ -716,7 +727,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 266.94it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 354.96it/s]\n"
      ]
     },
     {
@@ -732,14 +743,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 12.87it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 14.42it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ MLPClassifier: (pvalue: 0.211)\n",
+      "✅ MLPClassifier: (pvalue: 0.054)\n",
       "Evaluating MLPRegressor()\n"
      ]
     },
@@ -747,14 +758,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:06<00:00, 14.71it/s]\n"
+      "100%|██████████| 100/100 [00:05<00:00, 18.09it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ MLPRegressor: (pvalue: 0.583)\n",
+      "✅ MLPRegressor: (pvalue: 0.368)\n",
       "⚠ MaxAbsScaler does not support sample_weight\n",
       "⚠ MeanShift does not support sample_weight\n",
       "⚠ MinMaxScaler does not support sample_weight\n",
@@ -766,7 +777,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 110.52it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 274.98it/s]\n"
      ]
     },
     {
@@ -791,7 +802,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 259.00it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 469.69it/s]\n"
      ]
     },
     {
@@ -810,7 +821,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 90.96it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 111.59it/s]\n"
      ]
     },
     {
@@ -825,7 +836,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 177.78it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 261.85it/s]\n"
      ]
     },
     {
@@ -856,14 +867,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 212.98it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 299.76it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ Perceptron: (pvalue: 0.016)\n",
+      "❌ Perceptron: (pvalue: 0.000)\n",
       "Evaluating PoissonRegressor()\n"
      ]
     },
@@ -871,7 +882,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 218.28it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 425.13it/s]\n"
      ]
     },
     {
@@ -890,7 +901,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 12.22it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 120.98it/s]\n"
      ]
     },
     {
@@ -906,7 +917,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  3%|▎         | 3/100 [00:00<00:04, 22.55it/s]\n"
+      "  3%|▎         | 3/100 [00:00<00:03, 27.53it/s]\n"
      ]
     },
     {
@@ -927,7 +938,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:11<00:00,  8.37it/s]\n"
+      "100%|██████████| 100/100 [00:09<00:00, 10.12it/s]\n"
      ]
     },
     {
@@ -942,7 +953,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:10<00:00,  9.20it/s]\n"
+      "100%|██████████| 100/100 [00:08<00:00, 11.13it/s]\n"
      ]
     },
     {
@@ -957,17 +968,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 63.72it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 82.66it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ RandomTreesEmbedding: (pvalue: 0.470)\n",
+      "✅ RandomTreesEmbedding: (pvalue: 0.583)\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(max_iter=100000, solver='sag')\n",
-      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #952. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Evaluating RidgeCV()\n"
      ]
     },
@@ -975,7 +986,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 76.56it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 98.12it/s]\n"
      ]
     },
     {
@@ -984,7 +995,7 @@
      "text": [
       "✅ RidgeCV: (pvalue: 1.000)\n",
       "Evaluating RidgeClassifier(max_iter=100000, solver='saga')\n",
-      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #790. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Evaluating RidgeClassifierCV()\n"
      ]
     },
@@ -992,7 +1003,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 24.80it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 58.29it/s]\n"
      ]
     },
     {
@@ -1008,7 +1019,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 217.44it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 299.59it/s]\n"
      ]
     },
     {
@@ -1023,7 +1034,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 720.75it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 902.24it/s]\n"
      ]
     },
     {
@@ -1038,7 +1049,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 103.92it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 133.53it/s]\n"
      ]
     },
     {
@@ -1053,7 +1064,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 209.08it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 302.03it/s]\n"
      ]
     },
     {
@@ -1082,7 +1093,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 113.88it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 182.62it/s]\n"
      ]
     },
     {
@@ -1099,7 +1110,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 160.18it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 468.85it/s]\n"
      ]
     },
     {
@@ -1121,7 +1132,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 222.36it/s]"
+      "100%|██████████| 1/1 [00:00<00:00, 569.18it/s]"
      ]
     },
     {
@@ -1191,7 +1202,7 @@
     "\n",
     "    print(f\"Evaluating {est}\")\n",
     "    try:\n",
-    "        result = check_weighted_repeated_estimator_fit_equivalence(\n",
+    "        result = check_scale_free_equivalence(\n",
     "            est,\n",
     "            est_name,\n",
     "            test_name=\"kstest\",\n",
@@ -1210,7 +1221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -1250,343 +1261,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "index",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "estimator_name",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "pvalue",
-         "rawType": "float64",
-         "type": "float"
-        },
-        {
-         "name": "deterministic_predictions",
-         "rawType": "bool",
-         "type": "boolean"
-        }
-       ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "4f137462-9cb0-4c2d-a3ee-8ba385f75f19",
-       "rows": [
-        [
-         "42",
-         "NuSVC",
-         "2.2087606931995054e-59",
-         "False"
-        ],
-        [
-         "48",
-         "RandomForestRegressor",
-         "2.2087606931995054e-59",
-         "False"
-        ],
-        [
-         "54",
-         "SVC",
-         "2.2087606931995054e-59",
-         "False"
-        ],
-        [
-         "47",
-         "RandomForestClassifier",
-         "4.417521386399011e-57",
-         "False"
-        ],
-        [
-         "2",
-         "BaggingClassifier",
-         "4.395433779467016e-55",
-         "False"
-        ],
-        [
-         "25",
-         "HistGradientBoostingClassifier",
-         "5.600644140061753e-50",
-         "False"
-        ],
-        [
-         "53",
-         "SGDRegressor",
-         "2.596277269141426e-44",
-         "False"
-        ],
-        [
-         "35",
-         "LinearSVC",
-         "6.314161651442317e-19",
-         "False"
-        ],
-        [
-         "26",
-         "HistGradientBoostingRegressor",
-         "2.7084430241713094e-18",
-         "False"
-        ],
-        [
-         "3",
-         "BaggingRegressor",
-         "4.528308394643339e-17",
-         "False"
-        ],
-        [
-         "36",
-         "LinearSVR",
-         "2.458151170682656e-15",
-         "False"
-        ],
-        [
-         "37",
-         "LogisticRegression",
-         "3.751914289152195e-06",
-         "False"
-        ],
-        [
-         "52",
-         "SGDClassifier",
-         "7.850159128072286e-06",
-         "False"
-        ],
-        [
-         "20",
-         "ExtraTreesRegressor",
-         "3.211428734211389e-05",
-         "False"
-        ],
-        [
-         "44",
-         "Perceptron",
-         "0.015577131622877688",
-         "False"
-        ],
-        [
-         "15",
-         "ElasticNet",
-         "0.11119526053829192",
-         "False"
-        ],
-        [
-         "13",
-         "DummyClassifier",
-         "0.1548386665118475",
-         "False"
-        ],
-        [
-         "1",
-         "AdaBoostRegressor",
-         "0.1548386665118475",
-         "False"
-        ],
-        [
-         "23",
-         "GradientBoostingClassifier",
-         "0.1548386665118475",
-         "False"
-        ],
-        [
-         "24",
-         "GradientBoostingRegressor",
-         "0.21117008625127576",
-         "False"
-        ],
-        [
-         "38",
-         "MLPClassifier",
-         "0.21117008625127576",
-         "False"
-        ],
-        [
-         "12",
-         "DecisionTreeRegressor",
-         "0.2819416298082479",
-         "False"
-        ],
-        [
-         "16",
-         "ElasticNetCV",
-         "0.2819416298082479",
-         "False"
-        ],
-        [
-         "33",
-         "LassoCV",
-         "0.36818778606286096",
-         "False"
-        ],
-        [
-         "17",
-         "ExtraTreeClassifier",
-         "0.469506448503778",
-         "False"
-        ],
-        [
-         "49",
-         "RandomTreesEmbedding",
-         "0.469506448503778",
-         "False"
-        ],
-        [
-         "11",
-         "DecisionTreeClassifier",
-         "0.5830090612540064",
-         "False"
-        ],
-        [
-         "39",
-         "MLPRegressor",
-         "0.5830090612540064",
-         "False"
-        ],
-        [
-         "0",
-         "AdaBoostClassifier",
-         "0.8154147124661313",
-         "False"
-        ],
-        [
-         "29",
-         "KBinsDiscretizer",
-         "0.8154147124661313",
-         "False"
-        ],
-        [
-         "19",
-         "ExtraTreesClassifier",
-         "0.8154147124661313",
-         "False"
-        ],
-        [
-         "18",
-         "ExtraTreeRegressor",
-         "0.9996892272702655",
-         "False"
-        ],
-        [
-         "30",
-         "KMeans",
-         "1.0",
-         "False"
-        ],
-        [
-         "56",
-         "SplineTransformer",
-         "1.0",
-         "True"
-        ],
-        [
-         "55",
-         "SVR",
-         "1.0",
-         "True"
-        ],
-        [
-         "4",
-         "BayesianRidge",
-         "1.0",
-         "True"
-        ],
-        [
-         "5",
-         "BernoulliNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "6",
-         "BisectingKMeans",
-         "1.0",
-         "False"
-        ],
-        [
-         "51",
-         "RidgeClassifierCV",
-         "1.0",
-         "True"
-        ],
-        [
-         "50",
-         "RidgeCV",
-         "1.0",
-         "True"
-        ],
-        [
-         "7",
-         "CalibratedClassifierCV",
-         "1.0",
-         "True"
-        ],
-        [
-         "8",
-         "CategoricalNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "9",
-         "ComplementNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "46",
-         "QuantileRegressor",
-         "1.0",
-         "True"
-        ],
-        [
-         "45",
-         "PoissonRegressor",
-         "1.0",
-         "True"
-        ],
-        [
-         "10",
-         "DBSCAN",
-         "1.0",
-         "False"
-        ],
-        [
-         "43",
-         "NuSVR",
-         "1.0",
-         "True"
-        ],
-        [
-         "14",
-         "DummyRegressor",
-         "1.0",
-         "True"
-        ],
-        [
-         "41",
-         "MultinomialNB",
-         "1.0",
-         "True"
-        ],
-        [
-         "40",
-         "MiniBatchKMeans",
-         "1.0",
-         "False"
-        ]
-       ],
-       "shape": {
-        "columns": 3,
-        "rows": 59
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1619,14 +1298,14 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>48</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
+       "      <th>54</th>\n",
+       "      <td>SVC</td>\n",
        "      <td>2.208761e-59</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>54</th>\n",
-       "      <td>SVC</td>\n",
+       "      <th>48</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
        "      <td>2.208761e-59</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
@@ -1645,67 +1324,79 @@
        "    <tr>\n",
        "      <th>25</th>\n",
        "      <td>HistGradientBoostingClassifier</td>\n",
-       "      <td>5.600644e-50</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>53</th>\n",
-       "      <td>SGDRegressor</td>\n",
-       "      <td>2.596277e-44</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>35</th>\n",
-       "      <td>LinearSVC</td>\n",
-       "      <td>6.314162e-19</td>\n",
+       "      <td>2.900986e-53</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>26</th>\n",
        "      <td>HistGradientBoostingRegressor</td>\n",
-       "      <td>2.708443e-18</td>\n",
+       "      <td>3.231288e-37</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>SGDRegressor</td>\n",
+       "      <td>4.111260e-34</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>BaggingRegressor</td>\n",
-       "      <td>4.528308e-17</td>\n",
+       "      <td>3.357101e-13</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>36</th>\n",
-       "      <td>LinearSVR</td>\n",
-       "      <td>2.458151e-15</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>37</th>\n",
-       "      <td>LogisticRegression</td>\n",
-       "      <td>3.751914e-06</td>\n",
+       "      <th>35</th>\n",
+       "      <td>LinearSVC</td>\n",
+       "      <td>8.448372e-11</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>52</th>\n",
        "      <td>SGDClassifier</td>\n",
-       "      <td>7.850159e-06</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>3.211429e-05</td>\n",
+       "      <td>1.704797e-09</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>44</th>\n",
        "      <td>Perceptron</td>\n",
-       "      <td>1.557713e-02</td>\n",
+       "      <td>1.115168e-08</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>ElasticNet</td>\n",
+       "      <th>37</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>8.001544e-07</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36</th>\n",
+       "      <td>LinearSVR</td>\n",
+       "      <td>6.281177e-05</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AdaBoostRegressor</td>\n",
+       "      <td>3.638429e-02</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>5.390208e-02</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
        "      <td>1.111953e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>LassoCV</td>\n",
+       "      <td>1.548387e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1715,75 +1406,63 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>AdaBoostRegressor</td>\n",
-       "      <td>1.548387e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>23</th>\n",
        "      <td>GradientBoostingClassifier</td>\n",
-       "      <td>1.548387e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>2.111701e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38</th>\n",
-       "      <td>MLPClassifier</td>\n",
        "      <td>2.111701e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>12</th>\n",
        "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>2.111701e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
        "      <td>2.819416e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
+       "      <td>2.819416e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>3.681878e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>3.681878e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
        "      <td>ElasticNetCV</td>\n",
-       "      <td>2.819416e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>33</th>\n",
-       "      <td>LassoCV</td>\n",
-       "      <td>3.681878e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>ExtraTreeClassifier</td>\n",
        "      <td>4.695064e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>49</th>\n",
        "      <td>RandomTreesEmbedding</td>\n",
-       "      <td>4.695064e-01</td>\n",
+       "      <td>5.830091e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>DecisionTreeClassifier</td>\n",
-       "      <td>5.830091e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>39</th>\n",
-       "      <td>MLPRegressor</td>\n",
-       "      <td>5.830091e-01</td>\n",
+       "      <td>7.020570e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>AdaBoostClassifier</td>\n",
-       "      <td>8.154147e-01</td>\n",
+       "      <td>7.020570e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1793,15 +1472,15 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>ExtraTreesClassifier</td>\n",
+       "      <th>17</th>\n",
+       "      <td>ExtraTreeClassifier</td>\n",
        "      <td>8.154147e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>9.996892e-01</td>\n",
+       "      <th>19</th>\n",
+       "      <td>ExtraTreesClassifier</td>\n",
+       "      <td>9.684099e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1973,37 +1652,37 @@
       "text/plain": [
        "                    estimator_name        pvalue  deterministic_predictions\n",
        "42                           NuSVC  2.208761e-59                      False\n",
-       "48           RandomForestRegressor  2.208761e-59                      False\n",
        "54                             SVC  2.208761e-59                      False\n",
+       "48           RandomForestRegressor  2.208761e-59                      False\n",
        "47          RandomForestClassifier  4.417521e-57                      False\n",
        "2                BaggingClassifier  4.395434e-55                      False\n",
-       "25  HistGradientBoostingClassifier  5.600644e-50                      False\n",
-       "53                    SGDRegressor  2.596277e-44                      False\n",
-       "35                       LinearSVC  6.314162e-19                      False\n",
-       "26   HistGradientBoostingRegressor  2.708443e-18                      False\n",
-       "3                 BaggingRegressor  4.528308e-17                      False\n",
-       "36                       LinearSVR  2.458151e-15                      False\n",
-       "37              LogisticRegression  3.751914e-06                      False\n",
-       "52                   SGDClassifier  7.850159e-06                      False\n",
-       "20             ExtraTreesRegressor  3.211429e-05                      False\n",
-       "44                      Perceptron  1.557713e-02                      False\n",
-       "15                      ElasticNet  1.111953e-01                      False\n",
+       "25  HistGradientBoostingClassifier  2.900986e-53                      False\n",
+       "26   HistGradientBoostingRegressor  3.231288e-37                      False\n",
+       "53                    SGDRegressor  4.111260e-34                      False\n",
+       "3                 BaggingRegressor  3.357101e-13                      False\n",
+       "35                       LinearSVC  8.448372e-11                      False\n",
+       "52                   SGDClassifier  1.704797e-09                      False\n",
+       "44                      Perceptron  1.115168e-08                      False\n",
+       "37              LogisticRegression  8.001544e-07                      False\n",
+       "36                       LinearSVR  6.281177e-05                      False\n",
+       "1                AdaBoostRegressor  3.638429e-02                      False\n",
+       "38                   MLPClassifier  5.390208e-02                      False\n",
+       "24       GradientBoostingRegressor  1.111953e-01                      False\n",
+       "33                         LassoCV  1.548387e-01                      False\n",
        "13                 DummyClassifier  1.548387e-01                      False\n",
-       "1                AdaBoostRegressor  1.548387e-01                      False\n",
-       "23      GradientBoostingClassifier  1.548387e-01                      False\n",
-       "24       GradientBoostingRegressor  2.111701e-01                      False\n",
-       "38                   MLPClassifier  2.111701e-01                      False\n",
-       "12           DecisionTreeRegressor  2.819416e-01                      False\n",
-       "16                    ElasticNetCV  2.819416e-01                      False\n",
-       "33                         LassoCV  3.681878e-01                      False\n",
-       "17             ExtraTreeClassifier  4.695064e-01                      False\n",
-       "49            RandomTreesEmbedding  4.695064e-01                      False\n",
-       "11          DecisionTreeClassifier  5.830091e-01                      False\n",
-       "39                    MLPRegressor  5.830091e-01                      False\n",
-       "0               AdaBoostClassifier  8.154147e-01                      False\n",
+       "23      GradientBoostingClassifier  2.111701e-01                      False\n",
+       "12           DecisionTreeRegressor  2.111701e-01                      False\n",
+       "18              ExtraTreeRegressor  2.819416e-01                      False\n",
+       "20             ExtraTreesRegressor  2.819416e-01                      False\n",
+       "15                      ElasticNet  3.681878e-01                      False\n",
+       "39                    MLPRegressor  3.681878e-01                      False\n",
+       "16                    ElasticNetCV  4.695064e-01                      False\n",
+       "49            RandomTreesEmbedding  5.830091e-01                      False\n",
+       "11          DecisionTreeClassifier  7.020570e-01                      False\n",
+       "0               AdaBoostClassifier  7.020570e-01                      False\n",
        "29                KBinsDiscretizer  8.154147e-01                      False\n",
-       "19            ExtraTreesClassifier  8.154147e-01                      False\n",
-       "18              ExtraTreeRegressor  9.996892e-01                      False\n",
+       "17             ExtraTreeClassifier  8.154147e-01                      False\n",
+       "19            ExtraTreesClassifier  9.684099e-01                      False\n",
        "30                          KMeans  1.000000e+00                      False\n",
        "56               SplineTransformer  1.000000e+00                       True\n",
        "55                             SVR  1.000000e+00                       True\n",
@@ -2033,7 +1712,7 @@
        "58                TweedieRegressor  1.000000e+00                       True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2060,101 +1739,104 @@
      "text": [
       "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 312, in multifit_over_weighted_and_repeated\n",
-      "    est_weighted = check_pipeline_and_fit(\n",
-      "                   ^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "  File \"/var/folders/h4/l_wtcs4s43j2j9454pvp1c580000gn/T/ipykernel_98381/4270927197.py\", line 49, in <module>\n",
+      "    result = check_scale_free_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 98, in check_scale_free_equivalence\n",
+      "    ) = multifit_over_weighted_and_repeated(\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 496, in multifit_over_weighted_and_repeated\n",
+      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 311, in check_pipeline_and_fit\n",
       "    est = est.fit(X, y, sample_weight=sample_weight)\n",
       "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
       "    return f(*args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
       "    estimator.fit(X_subset, y_subset, **fit_params_subset)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
       "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
       "                                        ^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
       "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
       "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 598, in _average\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/utils/_array_api.py\", line 717, in _average\n",
       "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
       "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 575, in average\n",
+      "  File \"/Users/shrutinath/micromamba/envs/scikit-learn/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 570, in average\n",
       "    raise ZeroDivisionError(\n",
       "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
       "\n",
-      "❌ Ridge(max_iter=100000, solver='sag'): Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ Ridge(max_iter=100000, solver='sag'): Floating-point under-/overflow occurred at epoch #953. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
+      "  File \"/var/folders/h4/l_wtcs4s43j2j9454pvp1c580000gn/T/ipykernel_98381/4270927197.py\", line 49, in <module>\n",
+      "    result = check_scale_free_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 98, in check_scale_free_equivalence\n",
+      "    ) = multifit_over_weighted_and_repeated(\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 496, in multifit_over_weighted_and_repeated\n",
       "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
       "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 311, in check_pipeline_and_fit\n",
       "    est = est.fit(X, y, sample_weight=sample_weight)\n",
       "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1249, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ridge.py\", line 1249, in fit\n",
       "    return super().fit(X, y, sample_weight=sample_weight)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
       "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
       "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
       "    coef_, n_iter_, _ = sag_solver(\n",
       "                        ^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
       "    num_seen, n_iter_ = sag(\n",
       "                        ^^^^\n",
       "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #953. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "\n",
-      "❌ RidgeClassifier(max_iter=100000, solver='saga'): Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga'): Floating-point under-/overflow occurred at epoch #906. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
-      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
-      "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
+      "  File \"/var/folders/h4/l_wtcs4s43j2j9454pvp1c580000gn/T/ipykernel_98381/4270927197.py\", line 49, in <module>\n",
+      "    result = check_scale_free_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 98, in check_scale_free_equivalence\n",
+      "    ) = multifit_over_weighted_and_repeated(\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 496, in multifit_over_weighted_and_repeated\n",
       "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
       "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "  File \"/Users/shrutinath/sample_weight_audit_dist/reports/../src/sample_weight_audit/estimator_check.py\", line 311, in check_pipeline_and_fit\n",
       "    est = est.fit(X, y, sample_weight=sample_weight)\n",
       "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1571, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ridge.py\", line 1571, in fit\n",
       "    super().fit(X, Y, sample_weight=sample_weight)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
       "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
       "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
       "    coef_, n_iter_, _ = sag_solver(\n",
       "                        ^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
+      "  File \"/Users/shrutinath/sklearn-dev/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
       "    num_seen, n_iter_ = sag(\n",
       "                        ^^^^\n",
       "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #906. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "\n"
      ]
     }
@@ -2431,7 +2113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/reports/sklearn_estimators_sample_weight_scaling_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_scaling_audit_report.ipynb
@@ -2095,6 +2095,13 @@
     "from scipy.stats import kstest\n",
     "kstest(results.scores_repeated, results.scores_weighted)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/reports/sklearn_estimators_sample_weight_scaling_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_scaling_audit_report.ipynb
@@ -1,0 +1,2439 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## scikit-learn sample_weight compliance report\n",
+    "\n",
+    "This notebook runs compliance tests on all scikit-learn estimators. Estimator as inspected to check whether they are expected to have a stochastic fit or not. If the fit is stochastic, a dedicated statistical test is performed, otherwise a deterministic estimator check is run instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "System:\n",
+      "    python: 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]\n",
+      "executable: /Users/ogrisel/miniforge3/envs/dev/bin/python\n",
+      "   machine: macOS-15.2-arm64-arm-64bit\n",
+      "\n",
+      "Python dependencies:\n",
+      "      sklearn: 1.7.dev0\n",
+      "          pip: 25.0\n",
+      "   setuptools: 75.8.0\n",
+      "        numpy: 2.1.3\n",
+      "        scipy: 1.15.1\n",
+      "       Cython: 3.0.11\n",
+      "       pandas: 2.2.3\n",
+      "   matplotlib: 3.10.0\n",
+      "       joblib: 1.5.dev0\n",
+      "threadpoolctl: 3.5.0\n",
+      "\n",
+      "Built with OpenMP: True\n",
+      "\n",
+      "threadpoolctl info:\n",
+      "       user_api: openmp\n",
+      "   internal_api: openmp\n",
+      "    num_threads: 8\n",
+      "         prefix: libomp\n",
+      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libomp.dylib\n",
+      "        version: None\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sklearn\n",
+    "\n",
+    "sklearn.show_versions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from inspect import signature\n",
+    "import traceback\n",
+    "import warnings\n",
+    "import pandas as pd\n",
+    "from sklearn.utils import all_estimators\n",
+    "from sklearn.exceptions import ConvergenceWarning\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import KBinsDiscretizer\n",
+    "import threadpoolctl\n",
+    "\n",
+    "from sample_weight_audit import check_weighted_repeated_estimator_fit_equivalence\n",
+    "from sample_weight_audit.sklearn_stochastic_params import STOCHASTIC_FIT_PARAMS\n",
+    "\n",
+    "# HistGradientBoostingClassifier trashes the OpenMP thread pool on repeated\n",
+    "# small fits.\n",
+    "threadpoolctl.threadpool_limits(limits=1, user_api=\"openmp\")\n",
+    "warnings.filterwarnings(\"ignore\", category=RuntimeWarning)  # division by zero in AdaBoost\n",
+    "warnings.filterwarnings(\"ignore\", category=ConvergenceWarning)  # liblinear can fail to converge\n",
+    "warnings.filterwarnings(\"ignore\", category=UserWarning)  # KBinsDiscretizer with collapsed bins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import LogisticRegressionCV\n",
+    "\n",
+    "ESTIMATORS_TO_SKIP = [\n",
+    "    LogisticRegressionCV,  # too slow and already somewhat tested by LogisticRegression\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⚠ ARDRegression does not support sample_weight\n",
+      "Evaluating AdaBoostClassifier(estimator=DecisionTreeClassifier(max_features=0.5,\n",
+      "                                                    min_weight_fraction_leaf=0.1))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:07<00:00, 13.78it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ AdaBoostClassifier: (pvalue: 0.815)\n",
+      "Evaluating AdaBoostRegressor(estimator=DecisionTreeRegressor(max_features=0.5,\n",
+      "                                                  min_weight_fraction_leaf=0.1))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:05<00:00, 16.71it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ AdaBoostRegressor: (pvalue: 0.155)\n",
+      "⚠ AdditiveChi2Sampler does not support sample_weight\n",
+      "⚠ AffinityPropagation does not support sample_weight\n",
+      "⚠ AgglomerativeClustering does not support sample_weight\n",
+      "Evaluating BaggingClassifier(estimator=LogisticRegression())\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:04<00:00, 23.58it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ BaggingClassifier: (pvalue: 0.000)\n",
+      "Evaluating BaggingRegressor(estimator=Ridge())\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:01<00:00, 64.36it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ BaggingRegressor: (pvalue: 0.000)\n",
+      "Evaluating BayesianRidge()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 377.53it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ BayesianRidge: (pvalue: 1.000)\n",
+      "Evaluating BernoulliNB()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 18.91it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ BernoulliNB: (pvalue: 1.000)\n",
+      "⚠ BernoulliRBM does not support sample_weight\n",
+      "⚠ Binarizer does not support sample_weight\n",
+      "⚠ Birch does not support sample_weight\n",
+      "Evaluating BisectingKMeans(n_clusters=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 141.52it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ BisectingKMeans: (pvalue: 1.000)\n",
+      "⚠ CCA does not support sample_weight\n",
+      "Evaluating CalibratedClassifierCV()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 43.70it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ CalibratedClassifierCV: (pvalue: 1.000)\n",
+      "Evaluating Pipeline(steps=[('kbinsdiscretizer',\n",
+      "                 KBinsDiscretizer(encode='ordinal',\n",
+      "                                  quantile_method='averaged_inverted_cdf')),\n",
+      "                ('est', CategoricalNB())])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 94.80it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ CategoricalNB: (pvalue: 1.000)\n",
+      "⚠ ClassifierChain does not support sample_weight\n",
+      "⚠ ColumnTransformer does not support sample_weight\n",
+      "Evaluating ComplementNB()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 186.60it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ComplementNB: (pvalue: 1.000)\n",
+      "Evaluating DBSCAN()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 44.93it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ DBSCAN: (pvalue: 1.000)\n",
+      "Evaluating DecisionTreeClassifier(max_features=0.5, min_weight_fraction_leaf=0.1)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 449.98it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ DecisionTreeClassifier: (pvalue: 0.583)\n",
+      "Evaluating DecisionTreeRegressor(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 660.18it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ DecisionTreeRegressor: (pvalue: 0.282)\n",
+      "⚠ DictVectorizer does not support sample_weight\n",
+      "⚠ DictionaryLearning does not support sample_weight\n",
+      "Evaluating DummyClassifier(strategy='stratified')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 636.25it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ DummyClassifier: (pvalue: 0.155)\n",
+      "Evaluating DummyRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 615.00it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ DummyRegressor: (pvalue: 1.000)\n",
+      "Evaluating ElasticNet(selection='random')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 529.92it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ElasticNet: (pvalue: 0.111)\n",
+      "Evaluating ElasticNetCV(selection='random')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:02<00:00, 46.09it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ElasticNetCV: (pvalue: 0.282)\n",
+      "Evaluating ExtraTreeClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 378.24it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ExtraTreeClassifier: (pvalue: 0.470)\n",
+      "Evaluating ExtraTreeRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 555.15it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ExtraTreeRegressor: (pvalue: 1.000)\n",
+      "Evaluating ExtraTreesClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:09<00:00, 10.81it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ ExtraTreesClassifier: (pvalue: 0.815)\n",
+      "Evaluating ExtraTreesRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:08<00:00, 11.48it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ ExtraTreesRegressor: (pvalue: 0.000)\n",
+      "⚠ FactorAnalysis does not support sample_weight\n",
+      "⚠ FastICA does not support sample_weight\n",
+      "⚠ FeatureAgglomeration does not support sample_weight\n",
+      "⚠ FeatureHasher does not support sample_weight\n",
+      "⚠ FeatureUnion does not support sample_weight\n",
+      "⚠ FixedThresholdClassifier does not support sample_weight\n",
+      "⚠ FunctionTransformer does not support sample_weight\n",
+      "Evaluating GammaRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 224.87it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ GammaRegressor: (pvalue: 1.000)\n",
+      "Evaluating GaussianNB()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 275.11it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ GaussianNB: (pvalue: 1.000)\n",
+      "⚠ GaussianProcessClassifier does not support sample_weight\n",
+      "⚠ GaussianProcessRegressor does not support sample_weight\n",
+      "⚠ GaussianRandomProjection does not support sample_weight\n",
+      "⚠ GenericUnivariateSelect does not support sample_weight\n",
+      "Evaluating GradientBoostingClassifier(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:20<00:00,  4.78it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ GradientBoostingClassifier: (pvalue: 0.155)\n",
+      "Evaluating GradientBoostingRegressor(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:04<00:00, 22.22it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ GradientBoostingRegressor: (pvalue: 0.211)\n",
+      "⚠ HDBSCAN does not support sample_weight\n",
+      "⚠ HashingVectorizer does not support sample_weight\n",
+      "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:51<00:00,  1.93it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ HistGradientBoostingClassifier: (pvalue: 0.000)\n",
+      "Evaluating HistGradientBoostingRegressor(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:21<00:00,  4.76it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ HistGradientBoostingRegressor: (pvalue: 0.000)\n",
+      "Evaluating HuberRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 45.56it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ HuberRegressor: (pvalue: 1.000)\n",
+      "⚠ IncrementalPCA does not support sample_weight\n",
+      "⚠ Isomap does not support sample_weight\n",
+      "Evaluating IsotonicRegression()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 31.11it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ IsotonicRegression: (pvalue: 1.000)\n",
+      "Evaluating KBinsDiscretizer(encode='ordinal', quantile_method='averaged_inverted_cdf',\n",
+      "                 subsample=50)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 274.83it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ KBinsDiscretizer: (pvalue: 0.815)\n",
+      "Evaluating KMeans(n_clusters=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 294.86it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ KMeans: (pvalue: 1.000)\n",
+      "⚠ KNNImputer does not support sample_weight\n",
+      "⚠ KNeighborsClassifier does not support sample_weight\n",
+      "⚠ KNeighborsRegressor does not support sample_weight\n",
+      "⚠ KNeighborsTransformer does not support sample_weight\n",
+      "⚠ KernelCenterer does not support sample_weight\n",
+      "⚠ KernelPCA does not support sample_weight\n",
+      "Evaluating KernelRidge()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 330.60it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ KernelRidge: (pvalue: 1.000)\n",
+      "⚠ LabelBinarizer does not support sample_weight\n",
+      "⚠ LabelEncoder does not support sample_weight\n",
+      "⚠ LabelPropagation does not support sample_weight\n",
+      "⚠ LabelSpreading does not support sample_weight\n",
+      "⚠ Lars does not support sample_weight\n",
+      "⚠ LarsCV does not support sample_weight\n",
+      "Evaluating Lasso(selection='random')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 481.89it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Lasso: (pvalue: 1.000)\n",
+      "Evaluating LassoCV(selection='random')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:02<00:00, 45.64it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ LassoCV: (pvalue: 0.368)\n",
+      "⚠ LassoLars does not support sample_weight\n",
+      "⚠ LassoLarsCV does not support sample_weight\n",
+      "⚠ LassoLarsIC does not support sample_weight\n",
+      "⚠ LatentDirichletAllocation does not support sample_weight\n",
+      "⚠ LinearDiscriminantAnalysis does not support sample_weight\n",
+      "Evaluating LinearRegression()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 449.79it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ LinearRegression: (pvalue: 1.000)\n",
+      "Evaluating LinearSVC(dual=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 101.45it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ LinearSVC: (pvalue: 0.000)\n",
+      "Evaluating LinearSVR(dual=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 123.37it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ LinearSVR: (pvalue: 0.000)\n",
+      "⚠ LocallyLinearEmbedding does not support sample_weight\n",
+      "Evaluating LogisticRegression(dual=True, max_iter=100000, solver='liblinear')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 266.94it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ LogisticRegression: (pvalue: 0.000)\n",
+      "Skipping LogisticRegressionCV\n",
+      "Evaluating MLPClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:07<00:00, 12.87it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ MLPClassifier: (pvalue: 0.211)\n",
+      "Evaluating MLPRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:06<00:00, 14.71it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ MLPRegressor: (pvalue: 0.583)\n",
+      "⚠ MaxAbsScaler does not support sample_weight\n",
+      "⚠ MeanShift does not support sample_weight\n",
+      "⚠ MinMaxScaler does not support sample_weight\n",
+      "⚠ MiniBatchDictionaryLearning does not support sample_weight\n",
+      "Evaluating MiniBatchKMeans(n_clusters=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 110.52it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ MiniBatchKMeans: (pvalue: 1.000)\n",
+      "⚠ MiniBatchNMF does not support sample_weight\n",
+      "⚠ MiniBatchSparsePCA does not support sample_weight\n",
+      "⚠ MissingIndicator does not support sample_weight\n",
+      "⚠ MultiLabelBinarizer does not support sample_weight\n",
+      "⚠ MultiOutputClassifier failed to instantiate: MultiOutputClassifier.__init__() missing 1 required positional argument: 'estimator'\n",
+      "⚠ MultiOutputRegressor failed to instantiate: MultiOutputRegressor.__init__() missing 1 required positional argument: 'estimator'\n",
+      "⚠ MultiTaskElasticNet does not support sample_weight\n",
+      "⚠ MultiTaskElasticNetCV does not support sample_weight\n",
+      "⚠ MultiTaskLasso does not support sample_weight\n",
+      "⚠ MultiTaskLassoCV does not support sample_weight\n",
+      "Evaluating MultinomialNB()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 259.00it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ MultinomialNB: (pvalue: 1.000)\n",
+      "⚠ NMF does not support sample_weight\n",
+      "⚠ NearestCentroid does not support sample_weight\n",
+      "⚠ NeighborhoodComponentsAnalysis does not support sample_weight\n",
+      "⚠ Normalizer does not support sample_weight\n",
+      "Evaluating NuSVC(probability=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:01<00:00, 90.96it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ NuSVC: (pvalue: 0.000)\n",
+      "Evaluating NuSVR()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 177.78it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ NuSVR: (pvalue: 1.000)\n",
+      "⚠ Nystroem does not support sample_weight\n",
+      "⚠ OPTICS does not support sample_weight\n",
+      "⚠ OneHotEncoder does not support sample_weight\n",
+      "⚠ OneVsOneClassifier does not support sample_weight\n",
+      "⚠ OneVsRestClassifier does not support sample_weight\n",
+      "⚠ OrdinalEncoder does not support sample_weight\n",
+      "⚠ OrthogonalMatchingPursuit does not support sample_weight\n",
+      "⚠ OrthogonalMatchingPursuitCV does not support sample_weight\n",
+      "⚠ OutputCodeClassifier does not support sample_weight\n",
+      "⚠ PCA does not support sample_weight\n",
+      "⚠ PLSCanonical does not support sample_weight\n",
+      "⚠ PLSRegression does not support sample_weight\n",
+      "⚠ PLSSVD does not support sample_weight\n",
+      "⚠ PassiveAggressiveClassifier does not support sample_weight\n",
+      "⚠ PassiveAggressiveRegressor does not support sample_weight\n",
+      "⚠ PatchExtractor does not support sample_weight\n",
+      "Evaluating Perceptron(max_iter=100000)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 212.98it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Perceptron: (pvalue: 0.016)\n",
+      "Evaluating PoissonRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 218.28it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ PoissonRegressor: (pvalue: 1.000)\n",
+      "⚠ PolynomialCountSketch does not support sample_weight\n",
+      "⚠ PolynomialFeatures does not support sample_weight\n",
+      "⚠ PowerTransformer does not support sample_weight\n",
+      "⚠ QuadraticDiscriminantAnalysis does not support sample_weight\n",
+      "Evaluating QuantileRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 12.22it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ QuantileRegressor: (pvalue: 1.000)\n",
+      "⚠ QuantileTransformer does not support sample_weight\n",
+      "Evaluating RANSACRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  3%|▎         | 3/100 [00:00<00:04, 22.55it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RANSACRegressor() error with: Weights sum to zero, can't be normalized\n",
+      "⚠ RBFSampler does not support sample_weight\n",
+      "⚠ RFE does not support sample_weight\n",
+      "⚠ RFECV does not support sample_weight\n",
+      "⚠ RadiusNeighborsClassifier does not support sample_weight\n",
+      "⚠ RadiusNeighborsRegressor does not support sample_weight\n",
+      "⚠ RadiusNeighborsTransformer does not support sample_weight\n",
+      "Evaluating RandomForestClassifier()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:11<00:00,  8.37it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RandomForestClassifier: (pvalue: 0.000)\n",
+      "Evaluating RandomForestRegressor(max_features=0.5)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:10<00:00,  9.20it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RandomForestRegressor: (pvalue: 0.000)\n",
+      "Evaluating RandomTreesEmbedding(n_estimators=10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:01<00:00, 63.72it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ RandomTreesEmbedding: (pvalue: 0.470)\n",
+      "⚠ RegressorChain does not support sample_weight\n",
+      "Evaluating Ridge(max_iter=100000, solver='sag')\n",
+      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Evaluating RidgeCV()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 76.56it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ RidgeCV: (pvalue: 1.000)\n",
+      "Evaluating RidgeClassifier(max_iter=100000, solver='saga')\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Evaluating RidgeClassifierCV()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 24.80it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ RidgeClassifierCV: (pvalue: 1.000)\n",
+      "⚠ RobustScaler does not support sample_weight\n",
+      "Evaluating SGDClassifier(max_iter=100000)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 217.44it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ SGDClassifier: (pvalue: 0.000)\n",
+      "Evaluating SGDRegressor(max_iter=100000)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 720.75it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ SGDRegressor: (pvalue: 0.000)\n",
+      "Evaluating SVC(probability=True)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 103.92it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ SVC: (pvalue: 0.000)\n",
+      "Evaluating SVR()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 209.08it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ SVR: (pvalue: 1.000)\n",
+      "⚠ SelectFdr does not support sample_weight\n",
+      "⚠ SelectFpr does not support sample_weight\n",
+      "⚠ SelectFromModel does not support sample_weight\n",
+      "⚠ SelectFwe does not support sample_weight\n",
+      "⚠ SelectKBest does not support sample_weight\n",
+      "⚠ SelectPercentile does not support sample_weight\n",
+      "⚠ SelfTrainingClassifier does not support sample_weight\n",
+      "⚠ SequentialFeatureSelector does not support sample_weight\n",
+      "⚠ SimpleImputer does not support sample_weight\n",
+      "⚠ SkewedChi2Sampler does not support sample_weight\n",
+      "⚠ SparseCoder does not support sample_weight\n",
+      "⚠ SparsePCA does not support sample_weight\n",
+      "⚠ SparseRandomProjection does not support sample_weight\n",
+      "⚠ SpectralClustering does not support sample_weight\n",
+      "Evaluating SplineTransformer()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 113.88it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ SplineTransformer: (pvalue: 1.000)\n",
+      "⚠ StackingClassifier failed to instantiate: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
+      "⚠ StackingRegressor failed to instantiate: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'\n",
+      "Evaluating StandardScaler()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 160.18it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ StandardScaler: (pvalue: 1.000)\n",
+      "⚠ TSNE does not support sample_weight\n",
+      "⚠ TargetEncoder does not support sample_weight\n",
+      "⚠ TfidfTransformer does not support sample_weight\n",
+      "⚠ TheilSenRegressor does not support sample_weight\n",
+      "⚠ TransformedTargetRegressor does not support sample_weight\n",
+      "⚠ TruncatedSVD does not support sample_weight\n",
+      "⚠ TunedThresholdClassifierCV does not support sample_weight\n",
+      "Evaluating TweedieRegressor()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:00<00:00, 222.36it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ TweedieRegressor: (pvalue: 1.000)\n",
+      "⚠ VarianceThreshold does not support sample_weight\n",
+      "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
+      "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "N_STOCHASTIC_FITS = 100\n",
+    "N_STATISTICAL_TESTS = 58  # measured by running the script\n",
+    "BONFERRONI_CORRECTION = 1 / N_STATISTICAL_TESTS\n",
+    "TEST_THRESHOLD = 0.05 * BONFERRONI_CORRECTION\n",
+    "\n",
+    "\n",
+    "statistical_test_results = []\n",
+    "missing_sample_weight_support = []\n",
+    "errors = []\n",
+    "\n",
+    "\n",
+    "for est_name, est_class in all_estimators(\n",
+    "    type_filter=[\"classifier\", \"regressor\", \"cluster\", \"transformer\"]\n",
+    "):\n",
+    "    if est_class in ESTIMATORS_TO_SKIP:\n",
+    "        print(f\"Skipping {est_name}\")\n",
+    "        continue\n",
+    "\n",
+    "    if \"sample_weight\" not in signature(est_class.fit).parameters:\n",
+    "        print(f\"⚠ {est_name} does not support sample_weight\")\n",
+    "        missing_sample_weight_support.append(est_name)\n",
+    "        continue\n",
+    "\n",
+    "    try:\n",
+    "        if est_name == \"CategoricalNB\":\n",
+    "            # This estimator expects ordinal inputs so we need to discretize the input\n",
+    "            # features. This is not really valid but it's the best we can do while\n",
+    "            # keeping the dataset generation process common to all estimators of a\n",
+    "            # given type.\n",
+    "            est = Pipeline(\n",
+    "                steps=[\n",
+    "                    (\n",
+    "                        \"kbinsdiscretizer\",\n",
+    "                        KBinsDiscretizer(\n",
+    "                            encode=\"ordinal\", quantile_method=\"averaged_inverted_cdf\"\n",
+    "                        ),\n",
+    "                    ),\n",
+    "                    (\"est\", est_class(**STOCHASTIC_FIT_PARAMS.get(est_class, {}))),\n",
+    "                ]\n",
+    "            )\n",
+    "        else:\n",
+    "            est = est_class(**STOCHASTIC_FIT_PARAMS.get(est_class, {}))\n",
+    "    except TypeError as e:\n",
+    "        print(f\"⚠ {est_name} failed to instantiate: {e}\")\n",
+    "        continue\n",
+    "\n",
+    "    print(f\"Evaluating {est}\")\n",
+    "    try:\n",
+    "        result = check_weighted_repeated_estimator_fit_equivalence(\n",
+    "            est,\n",
+    "            est_name,\n",
+    "            test_name=\"kstest\",\n",
+    "            n_stochastic_fits=N_STOCHASTIC_FITS,\n",
+    "            random_state=0,\n",
+    "        )\n",
+    "        pass_or_fail = \"✅\" if result.pvalue > TEST_THRESHOLD else \"❌\"\n",
+    "        print(f\"{pass_or_fail} {est_name}: (pvalue: {result.pvalue:.3f})\")\n",
+    "        statistical_test_results.append(result)\n",
+    "    except Exception as e:\n",
+    "        print(f\"❌ {est} error with: {e}\")\n",
+    "        errors.append((est, e))\n",
+    "\n",
+    "results_df = pd.DataFrame([r.to_dict() for r in statistical_test_results])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ 45 passed the statistical test\n",
+      "❌ 14 failed the statistical test\n",
+      "❌ 3 other errors\n",
+      "⚠ 112 estimators lack sample_weight support\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\n",
+    "    f\"✅ {len([r for r in statistical_test_results if r.pvalue > TEST_THRESHOLD])} \"\n",
+    "    \"passed the statistical test\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"❌ {len([r for r in statistical_test_results if r.pvalue <= TEST_THRESHOLD])} \"\n",
+    "    \"failed the statistical test\"\n",
+    ")\n",
+    "print(f\"❌ {len(errors)} other errors\")\n",
+    "print(\n",
+    "    f\"⚠ {len(missing_sample_weight_support)} estimators lack sample_weight \"\n",
+    "    \"support\"\n",
+    ")\n",
+    "results_df = pd.DataFrame([r.to_dict() for r in statistical_test_results])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Details on the statistical test results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "estimator_name",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "pvalue",
+         "rawType": "float64",
+         "type": "float"
+        },
+        {
+         "name": "deterministic_predictions",
+         "rawType": "bool",
+         "type": "boolean"
+        }
+       ],
+       "conversionMethod": "pd.DataFrame",
+       "ref": "4f137462-9cb0-4c2d-a3ee-8ba385f75f19",
+       "rows": [
+        [
+         "42",
+         "NuSVC",
+         "2.2087606931995054e-59",
+         "False"
+        ],
+        [
+         "48",
+         "RandomForestRegressor",
+         "2.2087606931995054e-59",
+         "False"
+        ],
+        [
+         "54",
+         "SVC",
+         "2.2087606931995054e-59",
+         "False"
+        ],
+        [
+         "47",
+         "RandomForestClassifier",
+         "4.417521386399011e-57",
+         "False"
+        ],
+        [
+         "2",
+         "BaggingClassifier",
+         "4.395433779467016e-55",
+         "False"
+        ],
+        [
+         "25",
+         "HistGradientBoostingClassifier",
+         "5.600644140061753e-50",
+         "False"
+        ],
+        [
+         "53",
+         "SGDRegressor",
+         "2.596277269141426e-44",
+         "False"
+        ],
+        [
+         "35",
+         "LinearSVC",
+         "6.314161651442317e-19",
+         "False"
+        ],
+        [
+         "26",
+         "HistGradientBoostingRegressor",
+         "2.7084430241713094e-18",
+         "False"
+        ],
+        [
+         "3",
+         "BaggingRegressor",
+         "4.528308394643339e-17",
+         "False"
+        ],
+        [
+         "36",
+         "LinearSVR",
+         "2.458151170682656e-15",
+         "False"
+        ],
+        [
+         "37",
+         "LogisticRegression",
+         "3.751914289152195e-06",
+         "False"
+        ],
+        [
+         "52",
+         "SGDClassifier",
+         "7.850159128072286e-06",
+         "False"
+        ],
+        [
+         "20",
+         "ExtraTreesRegressor",
+         "3.211428734211389e-05",
+         "False"
+        ],
+        [
+         "44",
+         "Perceptron",
+         "0.015577131622877688",
+         "False"
+        ],
+        [
+         "15",
+         "ElasticNet",
+         "0.11119526053829192",
+         "False"
+        ],
+        [
+         "13",
+         "DummyClassifier",
+         "0.1548386665118475",
+         "False"
+        ],
+        [
+         "1",
+         "AdaBoostRegressor",
+         "0.1548386665118475",
+         "False"
+        ],
+        [
+         "23",
+         "GradientBoostingClassifier",
+         "0.1548386665118475",
+         "False"
+        ],
+        [
+         "24",
+         "GradientBoostingRegressor",
+         "0.21117008625127576",
+         "False"
+        ],
+        [
+         "38",
+         "MLPClassifier",
+         "0.21117008625127576",
+         "False"
+        ],
+        [
+         "12",
+         "DecisionTreeRegressor",
+         "0.2819416298082479",
+         "False"
+        ],
+        [
+         "16",
+         "ElasticNetCV",
+         "0.2819416298082479",
+         "False"
+        ],
+        [
+         "33",
+         "LassoCV",
+         "0.36818778606286096",
+         "False"
+        ],
+        [
+         "17",
+         "ExtraTreeClassifier",
+         "0.469506448503778",
+         "False"
+        ],
+        [
+         "49",
+         "RandomTreesEmbedding",
+         "0.469506448503778",
+         "False"
+        ],
+        [
+         "11",
+         "DecisionTreeClassifier",
+         "0.5830090612540064",
+         "False"
+        ],
+        [
+         "39",
+         "MLPRegressor",
+         "0.5830090612540064",
+         "False"
+        ],
+        [
+         "0",
+         "AdaBoostClassifier",
+         "0.8154147124661313",
+         "False"
+        ],
+        [
+         "29",
+         "KBinsDiscretizer",
+         "0.8154147124661313",
+         "False"
+        ],
+        [
+         "19",
+         "ExtraTreesClassifier",
+         "0.8154147124661313",
+         "False"
+        ],
+        [
+         "18",
+         "ExtraTreeRegressor",
+         "0.9996892272702655",
+         "False"
+        ],
+        [
+         "30",
+         "KMeans",
+         "1.0",
+         "False"
+        ],
+        [
+         "56",
+         "SplineTransformer",
+         "1.0",
+         "True"
+        ],
+        [
+         "55",
+         "SVR",
+         "1.0",
+         "True"
+        ],
+        [
+         "4",
+         "BayesianRidge",
+         "1.0",
+         "True"
+        ],
+        [
+         "5",
+         "BernoulliNB",
+         "1.0",
+         "True"
+        ],
+        [
+         "6",
+         "BisectingKMeans",
+         "1.0",
+         "False"
+        ],
+        [
+         "51",
+         "RidgeClassifierCV",
+         "1.0",
+         "True"
+        ],
+        [
+         "50",
+         "RidgeCV",
+         "1.0",
+         "True"
+        ],
+        [
+         "7",
+         "CalibratedClassifierCV",
+         "1.0",
+         "True"
+        ],
+        [
+         "8",
+         "CategoricalNB",
+         "1.0",
+         "True"
+        ],
+        [
+         "9",
+         "ComplementNB",
+         "1.0",
+         "True"
+        ],
+        [
+         "46",
+         "QuantileRegressor",
+         "1.0",
+         "True"
+        ],
+        [
+         "45",
+         "PoissonRegressor",
+         "1.0",
+         "True"
+        ],
+        [
+         "10",
+         "DBSCAN",
+         "1.0",
+         "False"
+        ],
+        [
+         "43",
+         "NuSVR",
+         "1.0",
+         "True"
+        ],
+        [
+         "14",
+         "DummyRegressor",
+         "1.0",
+         "True"
+        ],
+        [
+         "41",
+         "MultinomialNB",
+         "1.0",
+         "True"
+        ],
+        [
+         "40",
+         "MiniBatchKMeans",
+         "1.0",
+         "False"
+        ]
+       ],
+       "shape": {
+        "columns": 3,
+        "rows": 59
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>estimator_name</th>\n",
+       "      <th>pvalue</th>\n",
+       "      <th>deterministic_predictions</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>42</th>\n",
+       "      <td>NuSVC</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>48</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>54</th>\n",
+       "      <td>SVC</td>\n",
+       "      <td>2.208761e-59</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47</th>\n",
+       "      <td>RandomForestClassifier</td>\n",
+       "      <td>4.417521e-57</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingClassifier</td>\n",
+       "      <td>4.395434e-55</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>HistGradientBoostingClassifier</td>\n",
+       "      <td>5.600644e-50</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>53</th>\n",
+       "      <td>SGDRegressor</td>\n",
+       "      <td>2.596277e-44</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>LinearSVC</td>\n",
+       "      <td>6.314162e-19</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>HistGradientBoostingRegressor</td>\n",
+       "      <td>2.708443e-18</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BaggingRegressor</td>\n",
+       "      <td>4.528308e-17</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36</th>\n",
+       "      <td>LinearSVR</td>\n",
+       "      <td>2.458151e-15</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>37</th>\n",
+       "      <td>LogisticRegression</td>\n",
+       "      <td>3.751914e-06</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>52</th>\n",
+       "      <td>SGDClassifier</td>\n",
+       "      <td>7.850159e-06</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>ExtraTreesRegressor</td>\n",
+       "      <td>3.211429e-05</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>44</th>\n",
+       "      <td>Perceptron</td>\n",
+       "      <td>1.557713e-02</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>ElasticNet</td>\n",
+       "      <td>1.111953e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>DummyClassifier</td>\n",
+       "      <td>1.548387e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AdaBoostRegressor</td>\n",
+       "      <td>1.548387e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>GradientBoostingClassifier</td>\n",
+       "      <td>1.548387e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
+       "      <td>2.111701e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>MLPClassifier</td>\n",
+       "      <td>2.111701e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>DecisionTreeRegressor</td>\n",
+       "      <td>2.819416e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>ElasticNetCV</td>\n",
+       "      <td>2.819416e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>LassoCV</td>\n",
+       "      <td>3.681878e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>ExtraTreeClassifier</td>\n",
+       "      <td>4.695064e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>RandomTreesEmbedding</td>\n",
+       "      <td>4.695064e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>DecisionTreeClassifier</td>\n",
+       "      <td>5.830091e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
+       "      <td>MLPRegressor</td>\n",
+       "      <td>5.830091e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AdaBoostClassifier</td>\n",
+       "      <td>8.154147e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>KBinsDiscretizer</td>\n",
+       "      <td>8.154147e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>ExtraTreesClassifier</td>\n",
+       "      <td>8.154147e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>ExtraTreeRegressor</td>\n",
+       "      <td>9.996892e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>KMeans</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>56</th>\n",
+       "      <td>SplineTransformer</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55</th>\n",
+       "      <td>SVR</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>BayesianRidge</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>BernoulliNB</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>BisectingKMeans</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51</th>\n",
+       "      <td>RidgeClassifierCV</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50</th>\n",
+       "      <td>RidgeCV</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>CalibratedClassifierCV</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>CategoricalNB</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>ComplementNB</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>46</th>\n",
+       "      <td>QuantileRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45</th>\n",
+       "      <td>PoissonRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>DBSCAN</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>43</th>\n",
+       "      <td>NuSVR</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>DummyRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>41</th>\n",
+       "      <td>MultinomialNB</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>40</th>\n",
+       "      <td>MiniBatchKMeans</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>GammaRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>GaussianNB</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>HuberRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>34</th>\n",
+       "      <td>LinearRegression</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>IsotonicRegression</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32</th>\n",
+       "      <td>Lasso</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>KernelRidge</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>57</th>\n",
+       "      <td>StandardScaler</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>58</th>\n",
+       "      <td>TweedieRegressor</td>\n",
+       "      <td>1.000000e+00</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    estimator_name        pvalue  deterministic_predictions\n",
+       "42                           NuSVC  2.208761e-59                      False\n",
+       "48           RandomForestRegressor  2.208761e-59                      False\n",
+       "54                             SVC  2.208761e-59                      False\n",
+       "47          RandomForestClassifier  4.417521e-57                      False\n",
+       "2                BaggingClassifier  4.395434e-55                      False\n",
+       "25  HistGradientBoostingClassifier  5.600644e-50                      False\n",
+       "53                    SGDRegressor  2.596277e-44                      False\n",
+       "35                       LinearSVC  6.314162e-19                      False\n",
+       "26   HistGradientBoostingRegressor  2.708443e-18                      False\n",
+       "3                 BaggingRegressor  4.528308e-17                      False\n",
+       "36                       LinearSVR  2.458151e-15                      False\n",
+       "37              LogisticRegression  3.751914e-06                      False\n",
+       "52                   SGDClassifier  7.850159e-06                      False\n",
+       "20             ExtraTreesRegressor  3.211429e-05                      False\n",
+       "44                      Perceptron  1.557713e-02                      False\n",
+       "15                      ElasticNet  1.111953e-01                      False\n",
+       "13                 DummyClassifier  1.548387e-01                      False\n",
+       "1                AdaBoostRegressor  1.548387e-01                      False\n",
+       "23      GradientBoostingClassifier  1.548387e-01                      False\n",
+       "24       GradientBoostingRegressor  2.111701e-01                      False\n",
+       "38                   MLPClassifier  2.111701e-01                      False\n",
+       "12           DecisionTreeRegressor  2.819416e-01                      False\n",
+       "16                    ElasticNetCV  2.819416e-01                      False\n",
+       "33                         LassoCV  3.681878e-01                      False\n",
+       "17             ExtraTreeClassifier  4.695064e-01                      False\n",
+       "49            RandomTreesEmbedding  4.695064e-01                      False\n",
+       "11          DecisionTreeClassifier  5.830091e-01                      False\n",
+       "39                    MLPRegressor  5.830091e-01                      False\n",
+       "0               AdaBoostClassifier  8.154147e-01                      False\n",
+       "29                KBinsDiscretizer  8.154147e-01                      False\n",
+       "19            ExtraTreesClassifier  8.154147e-01                      False\n",
+       "18              ExtraTreeRegressor  9.996892e-01                      False\n",
+       "30                          KMeans  1.000000e+00                      False\n",
+       "56               SplineTransformer  1.000000e+00                       True\n",
+       "55                             SVR  1.000000e+00                       True\n",
+       "4                    BayesianRidge  1.000000e+00                       True\n",
+       "5                      BernoulliNB  1.000000e+00                       True\n",
+       "6                  BisectingKMeans  1.000000e+00                      False\n",
+       "51               RidgeClassifierCV  1.000000e+00                       True\n",
+       "50                         RidgeCV  1.000000e+00                       True\n",
+       "7           CalibratedClassifierCV  1.000000e+00                       True\n",
+       "8                    CategoricalNB  1.000000e+00                       True\n",
+       "9                     ComplementNB  1.000000e+00                       True\n",
+       "46               QuantileRegressor  1.000000e+00                       True\n",
+       "45                PoissonRegressor  1.000000e+00                       True\n",
+       "10                          DBSCAN  1.000000e+00                      False\n",
+       "43                           NuSVR  1.000000e+00                       True\n",
+       "14                  DummyRegressor  1.000000e+00                       True\n",
+       "41                   MultinomialNB  1.000000e+00                       True\n",
+       "40                 MiniBatchKMeans  1.000000e+00                      False\n",
+       "21                  GammaRegressor  1.000000e+00                       True\n",
+       "22                      GaussianNB  1.000000e+00                       True\n",
+       "27                  HuberRegressor  1.000000e+00                       True\n",
+       "34                LinearRegression  1.000000e+00                       True\n",
+       "28              IsotonicRegression  1.000000e+00                       True\n",
+       "32                           Lasso  1.000000e+00                       True\n",
+       "31                     KernelRidge  1.000000e+00                       True\n",
+       "57                  StandardScaler  1.000000e+00                       True\n",
+       "58                TweedieRegressor  1.000000e+00                       True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results_df.sort_values(\"pvalue\")[[\"estimator_name\", \"pvalue\", \"deterministic_predictions\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Details on errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "    multifit_over_weighted_and_repeated(\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 312, in multifit_over_weighted_and_repeated\n",
+      "    est_weighted = check_pipeline_and_fit(\n",
+      "                   ^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
+      "    return f(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
+      "    estimator.fit(X_subset, y_subset, **fit_params_subset)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
+      "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
+      "                                        ^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
+      "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
+      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 598, in _average\n",
+      "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
+      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 575, in average\n",
+      "    raise ZeroDivisionError(\n",
+      "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
+      "\n",
+      "❌ Ridge(max_iter=100000, solver='sag'): Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "    multifit_over_weighted_and_repeated(\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
+      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1249, in fit\n",
+      "    return super().fit(X, y, sample_weight=sample_weight)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
+      "                                             ^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "    coef_, n_iter_, _ = sag_solver(\n",
+      "                        ^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
+      "    num_seen, n_iter_ = sag(\n",
+      "                        ^^^^\n",
+      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga'): Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "    multifit_over_weighted_and_repeated(\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
+      "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
+      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "    est = est.fit(X, y, sample_weight=sample_weight)\n",
+      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    return fit_method(estimator, *args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1571, in fit\n",
+      "    super().fit(X, Y, sample_weight=sample_weight)\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
+      "                                             ^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "    coef_, n_iter_, _ = sag_solver(\n",
+      "                        ^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
+      "    num_seen, n_iter_ = sag(\n",
+      "                        ^^^^\n",
+      "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "for est, e in errors:\n",
+    "    print(f\"❌ {est}: {e}\")\n",
+    "    traceback.print_exception(e, file=sys.stdout)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List of estimators with missing sample_weight support"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ARDRegression\n",
+      "AdditiveChi2Sampler\n",
+      "AffinityPropagation\n",
+      "AgglomerativeClustering\n",
+      "BernoulliRBM\n",
+      "Binarizer\n",
+      "Birch\n",
+      "CCA\n",
+      "ClassifierChain\n",
+      "ColumnTransformer\n",
+      "DictVectorizer\n",
+      "DictionaryLearning\n",
+      "FactorAnalysis\n",
+      "FastICA\n",
+      "FeatureAgglomeration\n",
+      "FeatureHasher\n",
+      "FeatureUnion\n",
+      "FixedThresholdClassifier\n",
+      "FunctionTransformer\n",
+      "GaussianProcessClassifier\n",
+      "GaussianProcessRegressor\n",
+      "GaussianRandomProjection\n",
+      "GenericUnivariateSelect\n",
+      "HDBSCAN\n",
+      "HashingVectorizer\n",
+      "IncrementalPCA\n",
+      "Isomap\n",
+      "KNNImputer\n",
+      "KNeighborsClassifier\n",
+      "KNeighborsRegressor\n",
+      "KNeighborsTransformer\n",
+      "KernelCenterer\n",
+      "KernelPCA\n",
+      "LabelBinarizer\n",
+      "LabelEncoder\n",
+      "LabelPropagation\n",
+      "LabelSpreading\n",
+      "Lars\n",
+      "LarsCV\n",
+      "LassoLars\n",
+      "LassoLarsCV\n",
+      "LassoLarsIC\n",
+      "LatentDirichletAllocation\n",
+      "LinearDiscriminantAnalysis\n",
+      "LocallyLinearEmbedding\n",
+      "MaxAbsScaler\n",
+      "MeanShift\n",
+      "MinMaxScaler\n",
+      "MiniBatchDictionaryLearning\n",
+      "MiniBatchNMF\n",
+      "MiniBatchSparsePCA\n",
+      "MissingIndicator\n",
+      "MultiLabelBinarizer\n",
+      "MultiTaskElasticNet\n",
+      "MultiTaskElasticNetCV\n",
+      "MultiTaskLasso\n",
+      "MultiTaskLassoCV\n",
+      "NMF\n",
+      "NearestCentroid\n",
+      "NeighborhoodComponentsAnalysis\n",
+      "Normalizer\n",
+      "Nystroem\n",
+      "OPTICS\n",
+      "OneHotEncoder\n",
+      "OneVsOneClassifier\n",
+      "OneVsRestClassifier\n",
+      "OrdinalEncoder\n",
+      "OrthogonalMatchingPursuit\n",
+      "OrthogonalMatchingPursuitCV\n",
+      "OutputCodeClassifier\n",
+      "PCA\n",
+      "PLSCanonical\n",
+      "PLSRegression\n",
+      "PLSSVD\n",
+      "PassiveAggressiveClassifier\n",
+      "PassiveAggressiveRegressor\n",
+      "PatchExtractor\n",
+      "PolynomialCountSketch\n",
+      "PolynomialFeatures\n",
+      "PowerTransformer\n",
+      "QuadraticDiscriminantAnalysis\n",
+      "QuantileTransformer\n",
+      "RBFSampler\n",
+      "RFE\n",
+      "RFECV\n",
+      "RadiusNeighborsClassifier\n",
+      "RadiusNeighborsRegressor\n",
+      "RadiusNeighborsTransformer\n",
+      "RegressorChain\n",
+      "RobustScaler\n",
+      "SelectFdr\n",
+      "SelectFpr\n",
+      "SelectFromModel\n",
+      "SelectFwe\n",
+      "SelectKBest\n",
+      "SelectPercentile\n",
+      "SelfTrainingClassifier\n",
+      "SequentialFeatureSelector\n",
+      "SimpleImputer\n",
+      "SkewedChi2Sampler\n",
+      "SparseCoder\n",
+      "SparsePCA\n",
+      "SparseRandomProjection\n",
+      "SpectralClustering\n",
+      "TSNE\n",
+      "TargetEncoder\n",
+      "TfidfTransformer\n",
+      "TheilSenRegressor\n",
+      "TransformedTargetRegressor\n",
+      "TruncatedSVD\n",
+      "TunedThresholdClassifierCV\n",
+      "VarianceThreshold\n"
+     ]
+    }
+   ],
+   "source": [
+    "for est_name in missing_sample_weight_support:\n",
+    "    print(est_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example interactive inspection of the predictions and scores of a given estimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 3000)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results = next(r for r in statistical_test_results if r.estimator_name == \"GaussianNB\")\n",
+    "results.predictions_repeated.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 3000)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results.predictions_weighted.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.float64(3.9999992207384594e-10)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "np.abs(results.predictions_repeated - results.predictions_weighted).max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.float64(3.2652280879119644e-10)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.abs(results.scores_repeated - results.scores_weighted).max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "KstestResult(statistic=np.float64(1.0), pvalue=np.float64(1.0), statistic_location=np.float64(3.262703314947884), statistic_sign=np.int8(1))"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from scipy.stats import kstest\n",
+    "kstest(results.scores_repeated, results.scores_weighted)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/sample_weight_audit/__init__.py
+++ b/src/sample_weight_audit/__init__.py
@@ -1,4 +1,10 @@
-from .estimator_check import check_weighted_repeated_estimator_fit_equivalence
+from .estimator_check import (
+    check_weighted_repeated_estimator_fit_equivalence,
+    check_scale_free_equivalence,
+)
 
 
-__all__ = ["check_weighted_repeated_estimator_fit_equivalence"]
+__all__ = [
+    "check_weighted_repeated_estimator_fit_equivalence",
+    "check_scale_free_equivalence",
+]

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -370,7 +370,8 @@ def multifit_over_scaled_weights(
         n_stochastic_fits = 1  # avoid wasting time on deterministic estimators
 
     for seed in tqdm(range(n_stochastic_fits)):
-
+        rng = np.random.default_rng(seed)
+        scaling_factor = rng.randint(0, 10)
         if "random_state" in signature(est.__init__).parameters:
             est_weighted = clone(est).set_params(random_state=seed)
             # Use different random seeds for the other group of fits to avoid
@@ -386,12 +387,14 @@ def multifit_over_scaled_weights(
             est_weighted,
             X_train,
             y_train,
+            sample_weight=sample_weight_train,
             seed=seed,
         )
         est_scaled_weights = check_pipeline_and_fit(
             est_scaled_weights,
-            np.repeat(X_train, 2, axis=0),
-            np.repeat(y_train, 2, axis=0),
+            X_train,
+            y_train,
+            sample_weight=scaling_factor * sample_weight_train,
             seed=seed,
         )
 

--- a/src/tests/test_data.py
+++ b/src/tests/test_data.py
@@ -3,10 +3,13 @@ import pytest
 import numpy as np
 from sklearn import clone
 from sklearn.linear_model import LogisticRegression, Ridge
-from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import train_test_split
 
-from sample_weight_audit.data import make_data_for_estimator, get_diverse_subset
+from sample_weight_audit.data import (
+    make_data_for_estimator,
+    weighted_and_repeated_train_test_split,
+    get_diverse_subset,
+)
 
 
 @pytest.mark.parametrize("seed", [0, 1, 2])
@@ -49,7 +52,9 @@ def test_make_data_for_regressor(seed):
     assert y.ndim == 1
     assert X.shape[0] == y.shape[0] == sample_weight.shape[0]
     X_train, X_test, y_train, y_test, sample_weight_train, sample_weight_test = (
-        train_test_split(X, y, sample_weight, train_size=2000, random_state=seed)
+        weighted_and_repeated_train_test_split(
+            X, y, sample_weight, train_size=2000, random_state=seed, not_repeated=True
+        )
     )
 
     # Check that ignoring the weights leads to different coef values.


### PR DESCRIPTION
This is linked to issue #22 to first experimentally see whether scale-free invariance is respected amongst all deterministic and non-deterministic estimators. Ideally the worst offenders from the previous reports are the only ones where the property does not hold. Major changed:

- Moved the scaling of samples from "make_data_for_estimator" to "weighted_and_repeated_train_test_split" so we scale on train and test sets separately
- Added an additional multifit and check function for scaled weights

TO DO:

- [x] Investigate test errors
- [ ] Getting overflow error with Ridge and RidgeClassifier need to investigate @ogrisel if you have any ideas. Although this may be due to the test errors