### PR TITLE
Ensure sample_weight.sum() == sample_weight.shape[0]

### DIFF
--- a/src/sample_weight_audit/data.py
+++ b/src/sample_weight_audit/data.py
@@ -50,12 +50,13 @@ def weighted_and_repeated_train_test_split(
     )
 
 
-def make_data_for_estimator(
-    est, n_samples, n_features, n_classes=3, max_sample_weight=5, random_state=None
-):
+def make_data_for_estimator(est, n_samples, n_features, n_classes=3, random_state=None):
     # Strategy: sample 2 datasets, each with n_features // 2:
-    # - the first one has int(0.8 * n_samples) but mostly zero or one weights.
+    # - the first one has int(0.9 * n_samples) but mostly zero or one weights.
     # - the second one has the remaining samples but with higher weights.
+    # - the sum of all weights equals n_samples so that estimators that have
+    #   hyperparameters that depend on the sum of weights should behave the
+    #   same when fitted with sample weights or repeated samples.
     #
     # The features of the two datasets are horizontally stacked with random
     # feature values sampled independently from the other dataset. Then the two
@@ -66,7 +67,7 @@ def make_data_for_estimator(
     # features of the first dataset to learn their prediction function.
 
     rng = check_random_state(random_state)
-    n_samples_sw = int(0.8 * n_samples)  # small weights
+    n_samples_sw = int(0.9 * n_samples)  # small weights
     n_samples_lw = n_samples - n_samples_sw  # large weights
     n_features_sw = n_features // 2
     n_features_lw = n_features - n_features_sw
@@ -81,10 +82,27 @@ def make_data_for_estimator(
 
     # Construct the sample weights: mostly zeros and some ones for the first
     # dataset, and some random integers larger than one for the second dataset.
-    sample_weight_sw = np.where(rng.random(n_samples_sw) < 0.2, 1, 0)
-    sample_weight_lw = rng.randint(2, max_sample_weight, size=n_samples_lw)
-    total_weight_sum = np.sum(sample_weight_sw) + np.sum(sample_weight_lw)
-    assert np.sum(sample_weight_sw) < 0.3 * total_weight_sum
+    # Let's start with the second dataset, which has larger weights:
+    sample_weight_lw = rng.randint(low=3, high=11, size=n_samples_lw)
+    sample_weigh_lw_sum = np.sum(sample_weight_lw)
+    assert sample_weigh_lw_sum < n_samples
+    assert n_samples_sw > n_samples - sample_weigh_lw_sum
+
+    # Allocate 0 or 1 weights for the first dataset, such that the sum of all
+    # weights matches the total number of samples.
+    sample_weight_sw = np.zeros(n_samples_sw, dtype=sample_weight_lw.dtype)
+    weight_one_indices = rng.choice(
+        n_samples_sw, size=n_samples - sample_weigh_lw_sum, replace=False
+    )
+    sample_weight_sw[weight_one_indices] = 1
+    assert np.sum(sample_weight_sw) + sample_weigh_lw_sum == n_samples
+
+    sample_weight_sw_sum = np.sum(sample_weight_sw)
+    total_weight_sum = sample_weight_sw_sum + sample_weigh_lw_sum
+    assert sample_weight_sw_sum < 0.4 * total_weight_sum, (
+        sample_weight_sw_sum,
+        total_weight_sum,
+    )
 
     if not is_classifier(est):
         X_sw, y_sw = make_regression(

--- a/src/sample_weight_audit/estimator_check.py
+++ b/src/sample_weight_audit/estimator_check.py
@@ -63,7 +63,6 @@ def check_weighted_repeated_estimator_fit_equivalence(
     n_cv_group=3,
     n_features=10,
     n_classes=3,
-    max_sample_weight=10,
     n_stochastic_fits=300,
     random_state=None,
 ):
@@ -94,7 +93,6 @@ def check_weighted_repeated_estimator_fit_equivalence(
             n_stochastic_fits=n_stochastic_fits,
             n_samples_per_cv_group=n_samples_per_cv_group,
             n_cv_group=n_cv_group,
-            max_sample_weight=max_sample_weight,
             random_state=random_state,
         )
     )
@@ -233,7 +231,6 @@ def multifit_over_weighted_and_repeated(
     n_features=10,
     n_classes=3,
     test_pool_size=1000,
-    max_sample_weight=5,
     random_state=None,
 ):
     if "cv" in est.get_params():
@@ -248,7 +245,6 @@ def multifit_over_weighted_and_repeated(
         effective_train_size + test_pool_size,
         n_features=n_features,
         n_classes=n_classes,
-        max_sample_weight=max_sample_weight,
         random_state=random_state,
     )
 

--- a/src/tests/test_data.py
+++ b/src/tests/test_data.py
@@ -26,11 +26,12 @@ def test_make_data_for_classifier(seed):
     clf_with_sw = clone(clf).fit(X_train, y_train, sample_weight=sample_weight_train)
     clf_without_sw = clone(clf).fit(X_train, y_train)
 
-    assert np.abs(clf_with_sw.coef_[:, :5]).max() < 0.3
-    assert np.abs(clf_with_sw.coef_[:, 5:]).max() > 0.3
+    predictive_coef_magnitude = 0.3
+    assert np.abs(clf_with_sw.coef_[:, :5]).max() < predictive_coef_magnitude
+    assert np.abs(clf_with_sw.coef_[:, 5:]).max() > predictive_coef_magnitude
 
-    assert np.abs(clf_without_sw.coef_[:, :5]).max() > 0.3
-    assert np.abs(clf_without_sw.coef_[:, 5:]).max() < 0.3
+    assert np.abs(clf_without_sw.coef_[:, :5]).max() > predictive_coef_magnitude
+    assert np.abs(clf_without_sw.coef_[:, 5:]).max() < predictive_coef_magnitude
 
     assert np.abs(clf_with_sw.coef_ - clf_without_sw.coef_).max() > 0.1
 
@@ -56,7 +57,7 @@ def test_make_data_for_regressor(seed):
     reg_with_sw = clone(reg).fit(X_train, y_train, sample_weight=sample_weight_train)
     reg_without_sw = clone(reg).fit(X_train, y_train)
 
-    predictive_coef_magnitude = 0.4
+    predictive_coef_magnitude = 0.3
     assert np.abs(reg_with_sw.coef_[:5]).max() < predictive_coef_magnitude
     assert np.abs(reg_with_sw.coef_[5:]).max() > predictive_coef_magnitude
 


### PR DESCRIPTION
This will make sure that the stochastic test will not fail for the wrong reason for estimators that have hyper-parameters that depends on the number of data points in the training set.

Such estimator include `LogisticRegression` with a small value of `C` or `Ridge` with a large value of `alpha`.