### PR TITLE
Improve handling of the CV params and estimator that accept categorical inputs

### DIFF
--- a/reports/sklearn_estimators_sample_weight_audit_report.ipynb
+++ b/reports/sklearn_estimators_sample_weight_audit_report.ipynb
@@ -20,25 +20,34 @@
      "text": [
       "\n",
       "System:\n",
-      "    python: 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:19:53) [Clang 18.1.8 ]\n",
+      "    python: 3.13.3 | packaged by conda-forge | (main, Apr 14 2025, 20:44:30) [Clang 18.1.8 ]\n",
       "executable: /Users/ogrisel/miniforge3/envs/dev/bin/python\n",
-      "   machine: macOS-15.2-arm64-arm-64bit\n",
+      "   machine: macOS-15.5-arm64-arm-64bit-Mach-O\n",
       "\n",
       "Python dependencies:\n",
-      "      sklearn: 1.7.dev0\n",
-      "          pip: 25.0\n",
-      "   setuptools: 75.8.0\n",
-      "        numpy: 2.1.3\n",
-      "        scipy: 1.15.1\n",
-      "       Cython: 3.0.11\n",
+      "      sklearn: 1.8.dev0\n",
+      "          pip: 25.1.1\n",
+      "   setuptools: 75.8.2\n",
+      "        numpy: 2.2.6\n",
+      "        scipy: 1.15.2\n",
+      "       Cython: 3.1.1\n",
       "       pandas: 2.2.3\n",
-      "   matplotlib: 3.10.0\n",
-      "       joblib: 1.5.dev0\n",
-      "threadpoolctl: 3.5.0\n",
+      "   matplotlib: 3.10.3\n",
+      "       joblib: 1.5.1\n",
+      "threadpoolctl: 3.6.0\n",
       "\n",
       "Built with OpenMP: True\n",
       "\n",
       "threadpoolctl info:\n",
+      "       user_api: blas\n",
+      "   internal_api: openblas\n",
+      "    num_threads: 8\n",
+      "         prefix: libopenblas\n",
+      "       filepath: /Users/ogrisel/miniforge3/envs/dev/lib/libopenblas.0.dylib\n",
+      "        version: 0.3.29\n",
+      "threading_layer: openmp\n",
+      "   architecture: VORTEX\n",
+      "\n",
       "       user_api: openmp\n",
       "   internal_api: openmp\n",
       "    num_threads: 8\n",
@@ -112,7 +121,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 13.78it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 14.89it/s]\n"
      ]
     },
     {
@@ -128,14 +137,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:05<00:00, 16.71it/s]\n"
+      "100%|██████████| 100/100 [00:05<00:00, 17.99it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ AdaBoostRegressor: (pvalue: 0.155)\n",
+      "✅ AdaBoostRegressor: (pvalue: 0.054)\n",
       "⚠ AdditiveChi2Sampler does not support sample_weight\n",
       "⚠ AffinityPropagation does not support sample_weight\n",
       "⚠ AgglomerativeClustering does not support sample_weight\n",
@@ -146,14 +155,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:04<00:00, 23.58it/s]\n"
+      "100%|██████████| 100/100 [00:04<00:00, 21.57it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingClassifier: (pvalue: 0.000)\n",
+      "✅ BaggingClassifier: (pvalue: 0.111)\n",
       "Evaluating BaggingRegressor(estimator=Ridge())\n"
      ]
     },
@@ -161,14 +170,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 64.36it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 68.37it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "❌ BaggingRegressor: (pvalue: 0.000)\n",
+      "✅ BaggingRegressor: (pvalue: 0.470)\n",
       "Evaluating BayesianRidge()\n"
      ]
     },
@@ -176,7 +185,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 377.53it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 509.95it/s]\n"
      ]
     },
     {
@@ -191,7 +200,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 18.91it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 129.38it/s]\n"
      ]
     },
     {
@@ -209,7 +218,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 141.52it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 151.02it/s]\n"
      ]
     },
     {
@@ -225,7 +234,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 43.70it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 42.64it/s]\n"
      ]
     },
     {
@@ -233,17 +242,14 @@
      "output_type": "stream",
      "text": [
       "✅ CalibratedClassifierCV: (pvalue: 1.000)\n",
-      "Evaluating Pipeline(steps=[('kbinsdiscretizer',\n",
-      "                 KBinsDiscretizer(encode='ordinal',\n",
-      "                                  quantile_method='averaged_inverted_cdf')),\n",
-      "                ('est', CategoricalNB())])\n"
+      "Evaluating CategoricalNB()\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 94.80it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 181.88it/s]\n"
      ]
     },
     {
@@ -260,7 +266,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 186.60it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 101.25it/s]\n"
      ]
     },
     {
@@ -275,7 +281,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 44.93it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 37.81it/s]\n"
      ]
     },
     {
@@ -290,7 +296,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 449.98it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 426.14it/s]\n"
      ]
     },
     {
@@ -305,7 +311,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 660.18it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 505.99it/s]\n"
      ]
     },
     {
@@ -322,7 +328,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 636.25it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 629.77it/s]\n"
      ]
     },
     {
@@ -337,7 +343,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 615.00it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 608.22it/s]\n"
      ]
     },
     {
@@ -352,7 +358,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 529.92it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 530.70it/s]"
      ]
     },
     {
@@ -367,7 +373,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:02<00:00, 46.09it/s]\n"
+      "\n",
+      "100%|██████████| 100/100 [00:02<00:00, 49.96it/s]\n"
      ]
     },
     {
@@ -382,7 +389,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 378.24it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 494.00it/s]\n"
      ]
     },
     {
@@ -397,14 +404,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 555.15it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 736.92it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ ExtraTreeRegressor: (pvalue: 1.000)\n",
+      "✅ ExtraTreeRegressor: (pvalue: 0.908)\n",
       "Evaluating ExtraTreesClassifier()\n"
      ]
     },
@@ -412,7 +419,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:09<00:00, 10.81it/s]\n"
+      "100%|██████████| 100/100 [00:08<00:00, 11.27it/s]\n"
      ]
     },
     {
@@ -427,7 +434,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:08<00:00, 11.48it/s]\n"
+      "100%|██████████| 100/100 [00:08<00:00, 12.47it/s]\n"
      ]
     },
     {
@@ -449,7 +456,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 224.87it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 320.62it/s]\n"
      ]
     },
     {
@@ -464,7 +471,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 275.11it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 104.11it/s]\n"
      ]
     },
     {
@@ -483,7 +490,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:20<00:00,  4.78it/s]\n"
+      "100%|██████████| 100/100 [00:18<00:00,  5.45it/s]\n"
      ]
     },
     {
@@ -498,14 +505,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:04<00:00, 22.22it/s]\n"
+      "100%|██████████| 100/100 [00:03<00:00, 25.23it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ GradientBoostingRegressor: (pvalue: 0.211)\n",
+      "✅ GradientBoostingRegressor: (pvalue: 0.155)\n",
       "⚠ HDBSCAN does not support sample_weight\n",
       "⚠ HashingVectorizer does not support sample_weight\n",
       "Evaluating HistGradientBoostingClassifier(max_features=0.5)\n"
@@ -515,7 +522,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:51<00:00,  1.93it/s]\n"
+      "100%|██████████| 100/100 [00:42<00:00,  2.36it/s]\n"
      ]
     },
     {
@@ -530,7 +537,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:21<00:00,  4.76it/s]\n"
+      "100%|██████████| 100/100 [00:17<00:00,  5.63it/s]\n"
      ]
     },
     {
@@ -545,7 +552,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 45.56it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 35.68it/s]\n"
      ]
     },
     {
@@ -562,7 +569,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 31.11it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 576.38it/s]\n"
      ]
     },
     {
@@ -578,7 +585,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 274.83it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 267.79it/s]\n"
      ]
     },
     {
@@ -593,7 +600,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 294.86it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 332.35it/s]\n"
      ]
     },
     {
@@ -614,7 +621,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 330.60it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 212.14it/s]\n"
      ]
     },
     {
@@ -635,7 +642,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 481.89it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 763.15it/s]\n"
      ]
     },
     {
@@ -650,7 +657,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:02<00:00, 45.64it/s]\n"
+      "100%|██████████| 100/100 [00:02<00:00, 49.44it/s]\n"
      ]
     },
     {
@@ -670,7 +677,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 449.79it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 518.39it/s]\n"
      ]
     },
     {
@@ -685,7 +692,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 101.45it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 102.86it/s]\n"
      ]
     },
     {
@@ -700,7 +707,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 123.37it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 122.73it/s]\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n"
      ]
     },
     {
@@ -716,7 +725,407 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 266.94it/s]\n"
+      "  0%|          | 0/100 [00:00<?, ?it/s]/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      " 21%|██        | 21/100 [00:00<00:00, 208.66it/s]/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      " 47%|████▋     | 47/100 [00:00<00:00, 236.24it/s]/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      " 71%|███████   | 71/100 [00:00<00:00, 233.10it/s]/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      " 97%|█████████▋| 97/100 [00:00<00:00, 241.64it/s]/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_logistic.py:1288: FutureWarning: Using the 'liblinear' solver for multiclass classification is deprecated. An error will be raised in 1.8. Either use another solver which supports the multinomial loss or wrap the estimator in a OneVsRestClassifier to keep applying a one-versus-rest scheme.\n",
+      "  warnings.warn(\n",
+      "100%|██████████| 100/100 [00:00<00:00, 236.72it/s]\n"
      ]
     },
     {
@@ -732,7 +1141,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 12.87it/s]\n"
+      "100%|██████████| 100/100 [00:07<00:00, 12.78it/s]\n"
      ]
     },
     {
@@ -747,7 +1156,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:06<00:00, 14.71it/s]\n"
+      "100%|██████████| 100/100 [00:06<00:00, 15.34it/s]\n"
      ]
     },
     {
@@ -766,7 +1175,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 110.52it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 141.61it/s]\n"
      ]
     },
     {
@@ -791,7 +1200,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 259.00it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 305.15it/s]\n"
      ]
     },
     {
@@ -810,7 +1219,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 90.96it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 86.66it/s]\n"
      ]
     },
     {
@@ -825,7 +1234,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 177.78it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 194.98it/s]\n"
      ]
     },
     {
@@ -856,7 +1265,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 212.98it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 233.41it/s]\n"
      ]
     },
     {
@@ -871,7 +1280,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 218.28it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 261.85it/s]\n"
      ]
     },
     {
@@ -890,7 +1299,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 12.22it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00,  8.10it/s]\n"
      ]
     },
     {
@@ -906,7 +1315,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  3%|▎         | 3/100 [00:00<00:04, 22.55it/s]\n"
+      "  3%|▎         | 3/100 [00:00<00:04, 21.51it/s]\n"
      ]
     },
     {
@@ -927,7 +1336,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:11<00:00,  8.37it/s]\n"
+      "100%|██████████| 100/100 [00:11<00:00,  8.73it/s]\n"
      ]
     },
     {
@@ -942,7 +1351,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:10<00:00,  9.20it/s]\n"
+      "100%|██████████| 100/100 [00:10<00:00,  9.43it/s]\n"
      ]
     },
     {
@@ -957,7 +1366,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:01<00:00, 63.72it/s]\n"
+      "100%|██████████| 100/100 [00:01<00:00, 68.82it/s]\n"
      ]
     },
     {
@@ -967,7 +1376,7 @@
       "✅ RandomTreesEmbedding: (pvalue: 0.470)\n",
       "⚠ RegressorChain does not support sample_weight\n",
       "Evaluating Ridge(max_iter=100000, solver='sag')\n",
-      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ Ridge(max_iter=100000, solver='sag') error with: Floating-point under-/overflow occurred at epoch #981. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Evaluating RidgeCV()\n"
      ]
     },
@@ -975,7 +1384,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 76.56it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 91.96it/s]\n"
      ]
     },
     {
@@ -984,7 +1393,7 @@
      "text": [
       "✅ RidgeCV: (pvalue: 1.000)\n",
       "Evaluating RidgeClassifier(max_iter=100000, solver='saga')\n",
-      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga') error with: Floating-point under-/overflow occurred at epoch #861. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Evaluating RidgeClassifierCV()\n"
      ]
     },
@@ -992,7 +1401,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 24.80it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 34.77it/s]\n"
      ]
     },
     {
@@ -1008,7 +1417,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 217.44it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 217.79it/s]\n"
      ]
     },
     {
@@ -1023,7 +1432,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 720.75it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 766.04it/s]\n"
      ]
     },
     {
@@ -1038,7 +1447,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:00<00:00, 103.92it/s]\n"
+      "100%|██████████| 100/100 [00:00<00:00, 101.97it/s]\n"
      ]
     },
     {
@@ -1053,7 +1462,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 209.08it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 220.16it/s]\n"
      ]
     },
     {
@@ -1082,7 +1491,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 113.88it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 104.43it/s]\n"
      ]
     },
     {
@@ -1090,8 +1499,8 @@
      "output_type": "stream",
      "text": [
       "✅ SplineTransformer: (pvalue: 1.000)\n",
-      "⚠ StackingClassifier failed to instantiate: StackingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
-      "⚠ StackingRegressor failed to instantiate: StackingRegressor.__init__() missing 1 required positional argument: 'estimators'\n",
+      "⚠ StackingClassifier does not support sample_weight\n",
+      "⚠ StackingRegressor does not support sample_weight\n",
       "Evaluating StandardScaler()\n"
      ]
     },
@@ -1099,7 +1508,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 160.18it/s]\n"
+      "100%|██████████| 1/1 [00:00<00:00, 241.25it/s]\n"
      ]
     },
     {
@@ -1121,7 +1530,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:00<00:00, 222.36it/s]"
+      "100%|██████████| 1/1 [00:00<00:00, 63.10it/s]"
      ]
     },
     {
@@ -1130,8 +1539,8 @@
      "text": [
       "✅ TweedieRegressor: (pvalue: 1.000)\n",
       "⚠ VarianceThreshold does not support sample_weight\n",
-      "⚠ VotingClassifier failed to instantiate: VotingClassifier.__init__() missing 1 required positional argument: 'estimators'\n",
-      "⚠ VotingRegressor failed to instantiate: VotingRegressor.__init__() missing 1 required positional argument: 'estimators'\n"
+      "⚠ VotingClassifier does not support sample_weight\n",
+      "⚠ VotingRegressor does not support sample_weight\n"
      ]
     },
     {
@@ -1167,24 +1576,7 @@
     "        continue\n",
     "\n",
     "    try:\n",
-    "        if est_name == \"CategoricalNB\":\n",
-    "            # This estimator expects ordinal inputs so we need to discretize the input\n",
-    "            # features. This is not really valid but it's the best we can do while\n",
-    "            # keeping the dataset generation process common to all estimators of a\n",
-    "            # given type.\n",
-    "            est = Pipeline(\n",
-    "                steps=[\n",
-    "                    (\n",
-    "                        \"kbinsdiscretizer\",\n",
-    "                        KBinsDiscretizer(\n",
-    "                            encode=\"ordinal\", quantile_method=\"averaged_inverted_cdf\"\n",
-    "                        ),\n",
-    "                    ),\n",
-    "                    (\"est\", est_class(**STOCHASTIC_FIT_PARAMS.get(est_class, {}))),\n",
-    "                ]\n",
-    "            )\n",
-    "        else:\n",
-    "            est = est_class(**STOCHASTIC_FIT_PARAMS.get(est_class, {}))\n",
+    "        est = est_class(**STOCHASTIC_FIT_PARAMS.get(est_class, {}))\n",
     "    except TypeError as e:\n",
     "        print(f\"⚠ {est_name} failed to instantiate: {e}\")\n",
     "        continue\n",
@@ -1217,10 +1609,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✅ 45 passed the statistical test\n",
-      "❌ 14 failed the statistical test\n",
+      "✅ 47 passed the statistical test\n",
+      "❌ 12 failed the statistical test\n",
       "❌ 3 other errors\n",
-      "⚠ 112 estimators lack sample_weight support\n"
+      "⚠ 116 estimators lack sample_weight support\n"
      ]
     }
    ],
@@ -1278,18 +1670,11 @@
          "type": "boolean"
         }
        ],
-       "conversionMethod": "pd.DataFrame",
-       "ref": "4f137462-9cb0-4c2d-a3ee-8ba385f75f19",
+       "ref": "43f6888f-1482-4b9b-a433-106faf0b4310",
        "rows": [
         [
          "42",
          "NuSVC",
-         "2.2087606931995054e-59",
-         "False"
-        ],
-        [
-         "48",
-         "RandomForestRegressor",
          "2.2087606931995054e-59",
          "False"
         ],
@@ -1300,15 +1685,15 @@
          "False"
         ],
         [
-         "47",
-         "RandomForestClassifier",
-         "4.417521386399011e-57",
+         "48",
+         "RandomForestRegressor",
+         "2.2087606931995054e-59",
          "False"
         ],
         [
-         "2",
-         "BaggingClassifier",
-         "4.395433779467016e-55",
+         "47",
+         "RandomForestClassifier",
+         "4.417521386399011e-57",
          "False"
         ],
         [
@@ -1336,12 +1721,6 @@
          "False"
         ],
         [
-         "3",
-         "BaggingRegressor",
-         "4.528308394643339e-17",
-         "False"
-        ],
-        [
          "36",
          "LinearSVR",
          "2.458151170682656e-15",
@@ -1362,7 +1741,7 @@
         [
          "20",
          "ExtraTreesRegressor",
-         "3.211428734211389e-05",
+         "0.0004117410017938115",
          "False"
         ],
         [
@@ -1372,9 +1751,27 @@
          "False"
         ],
         [
+         "1",
+         "AdaBoostRegressor",
+         "0.05390207893129876",
+         "False"
+        ],
+        [
+         "2",
+         "BaggingClassifier",
+         "0.11119526053829192",
+         "False"
+        ],
+        [
          "15",
          "ElasticNet",
          "0.11119526053829192",
+         "False"
+        ],
+        [
+         "24",
+         "GradientBoostingRegressor",
+         "0.1548386665118475",
          "False"
         ],
         [
@@ -1384,21 +1781,9 @@
          "False"
         ],
         [
-         "1",
-         "AdaBoostRegressor",
-         "0.1548386665118475",
-         "False"
-        ],
-        [
          "23",
          "GradientBoostingClassifier",
          "0.1548386665118475",
-         "False"
-        ],
-        [
-         "24",
-         "GradientBoostingRegressor",
-         "0.21117008625127576",
          "False"
         ],
         [
@@ -1438,6 +1823,12 @@
          "False"
         ],
         [
+         "3",
+         "BaggingRegressor",
+         "0.469506448503778",
+         "False"
+        ],
+        [
          "11",
          "DecisionTreeClassifier",
          "0.5830090612540064",
@@ -1470,7 +1861,7 @@
         [
          "18",
          "ExtraTreeRegressor",
-         "0.9996892272702655",
+         "0.9084105017744525",
          "False"
         ],
         [
@@ -1619,14 +2010,14 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>48</th>\n",
-       "      <td>RandomForestRegressor</td>\n",
+       "      <th>54</th>\n",
+       "      <td>SVC</td>\n",
        "      <td>2.208761e-59</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>54</th>\n",
-       "      <td>SVC</td>\n",
+       "      <th>48</th>\n",
+       "      <td>RandomForestRegressor</td>\n",
        "      <td>2.208761e-59</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
@@ -1634,12 +2025,6 @@
        "      <th>47</th>\n",
        "      <td>RandomForestClassifier</td>\n",
        "      <td>4.417521e-57</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BaggingClassifier</td>\n",
-       "      <td>4.395434e-55</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1667,12 +2052,6 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>BaggingRegressor</td>\n",
-       "      <td>4.528308e-17</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>36</th>\n",
        "      <td>LinearSVR</td>\n",
        "      <td>2.458151e-15</td>\n",
@@ -1693,7 +2072,7 @@
        "    <tr>\n",
        "      <th>20</th>\n",
        "      <td>ExtraTreesRegressor</td>\n",
-       "      <td>3.211429e-05</td>\n",
+       "      <td>4.117410e-04</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1703,9 +2082,27 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AdaBoostRegressor</td>\n",
+       "      <td>5.390208e-02</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BaggingClassifier</td>\n",
+       "      <td>1.111953e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>15</th>\n",
        "      <td>ElasticNet</td>\n",
        "      <td>1.111953e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>GradientBoostingRegressor</td>\n",
+       "      <td>1.548387e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1715,21 +2112,9 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>AdaBoostRegressor</td>\n",
-       "      <td>1.548387e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>23</th>\n",
        "      <td>GradientBoostingClassifier</td>\n",
        "      <td>1.548387e-01</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>GradientBoostingRegressor</td>\n",
-       "      <td>2.111701e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1769,6 +2154,12 @@
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BaggingRegressor</td>\n",
+       "      <td>4.695064e-01</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>DecisionTreeClassifier</td>\n",
        "      <td>5.830091e-01</td>\n",
@@ -1801,7 +2192,7 @@
        "    <tr>\n",
        "      <th>18</th>\n",
        "      <td>ExtraTreeRegressor</td>\n",
-       "      <td>9.996892e-01</td>\n",
+       "      <td>9.084105e-01</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1973,37 +2364,37 @@
       "text/plain": [
        "                    estimator_name        pvalue  deterministic_predictions\n",
        "42                           NuSVC  2.208761e-59                      False\n",
-       "48           RandomForestRegressor  2.208761e-59                      False\n",
        "54                             SVC  2.208761e-59                      False\n",
+       "48           RandomForestRegressor  2.208761e-59                      False\n",
        "47          RandomForestClassifier  4.417521e-57                      False\n",
-       "2                BaggingClassifier  4.395434e-55                      False\n",
        "25  HistGradientBoostingClassifier  5.600644e-50                      False\n",
        "53                    SGDRegressor  2.596277e-44                      False\n",
        "35                       LinearSVC  6.314162e-19                      False\n",
        "26   HistGradientBoostingRegressor  2.708443e-18                      False\n",
-       "3                 BaggingRegressor  4.528308e-17                      False\n",
        "36                       LinearSVR  2.458151e-15                      False\n",
        "37              LogisticRegression  3.751914e-06                      False\n",
        "52                   SGDClassifier  7.850159e-06                      False\n",
-       "20             ExtraTreesRegressor  3.211429e-05                      False\n",
+       "20             ExtraTreesRegressor  4.117410e-04                      False\n",
        "44                      Perceptron  1.557713e-02                      False\n",
+       "1                AdaBoostRegressor  5.390208e-02                      False\n",
+       "2                BaggingClassifier  1.111953e-01                      False\n",
        "15                      ElasticNet  1.111953e-01                      False\n",
+       "24       GradientBoostingRegressor  1.548387e-01                      False\n",
        "13                 DummyClassifier  1.548387e-01                      False\n",
-       "1                AdaBoostRegressor  1.548387e-01                      False\n",
        "23      GradientBoostingClassifier  1.548387e-01                      False\n",
-       "24       GradientBoostingRegressor  2.111701e-01                      False\n",
        "38                   MLPClassifier  2.111701e-01                      False\n",
        "12           DecisionTreeRegressor  2.819416e-01                      False\n",
        "16                    ElasticNetCV  2.819416e-01                      False\n",
        "33                         LassoCV  3.681878e-01                      False\n",
        "17             ExtraTreeClassifier  4.695064e-01                      False\n",
        "49            RandomTreesEmbedding  4.695064e-01                      False\n",
+       "3                 BaggingRegressor  4.695064e-01                      False\n",
        "11          DecisionTreeClassifier  5.830091e-01                      False\n",
        "39                    MLPRegressor  5.830091e-01                      False\n",
        "0               AdaBoostClassifier  8.154147e-01                      False\n",
        "29                KBinsDiscretizer  8.154147e-01                      False\n",
        "19            ExtraTreesClassifier  8.154147e-01                      False\n",
-       "18              ExtraTreeRegressor  9.996892e-01                      False\n",
+       "18              ExtraTreeRegressor  9.084105e-01                      False\n",
        "30                          KMeans  1.000000e+00                      False\n",
        "56               SplineTransformer  1.000000e+00                       True\n",
        "55                             SVR  1.000000e+00                       True\n",
@@ -2060,101 +2451,176 @@
      "text": [
       "❌ RANSACRegressor(): Weights sum to zero, can't be normalized\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_36417/2557711519.py\", line 32, in <module>\n",
       "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "        est,\n",
+      "    ...<3 lines>...\n",
+      "        random_state=0,\n",
+      "    )\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 91, in check_weighted_repeated_estimator_fit_equivalence\n",
       "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 312, in multifit_over_weighted_and_repeated\n",
+      "    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n",
+      "        est,\n",
+      "        ^^^^\n",
+      "    ...<6 lines>...\n",
+      "        random_state=random_state,\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 331, in multifit_over_weighted_and_repeated\n",
       "    est_weighted = check_pipeline_and_fit(\n",
-      "                   ^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "        est_weighted,\n",
+      "    ...<3 lines>...\n",
+      "        seed=seed,\n",
+      "    )\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 241, in check_pipeline_and_fit\n",
       "    est = est.fit(X, y, sample_weight=sample_weight)\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1363, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py\", line 63, in inner_f\n",
-      "    return f(*args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ransac.py\", line 498, in fit\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ransac.py\", line 493, in fit\n",
       "    estimator.fit(X_subset, y_subset, **fit_params_subset)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1363, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 635, in fit\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 639, in fit\n",
       "    X, y, X_offset, y_offset, X_scale = _preprocess_data(\n",
-      "                                        ^^^^^^^^^^^^^^^^^\n",
+      "                                        ~~~~~~~~~~~~~~~~^\n",
+      "        X,\n",
+      "        ^^\n",
+      "    ...<3 lines>...\n",
+      "        sample_weight=sample_weight,\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_base.py\", line 185, in _preprocess_data\n",
       "    X_offset = _average(X, axis=0, weights=sample_weight, xp=xp)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 598, in _average\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/utils/_array_api.py\", line 617, in _average\n",
       "    return xp.asarray(numpy.average(a, axis=axis, weights=weights))\n",
-      "                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py\", line 575, in average\n",
+      "                      ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/miniforge3/envs/dev/lib/python3.13/site-packages/numpy/lib/_function_base_impl.py\", line 565, in average\n",
       "    raise ZeroDivisionError(\n",
+      "        \"Weights sum to zero, can't be normalized\")\n",
       "ZeroDivisionError: Weights sum to zero, can't be normalized\n",
       "\n",
-      "❌ Ridge(max_iter=100000, solver='sag'): Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ Ridge(max_iter=100000, solver='sag'): Floating-point under-/overflow occurred at epoch #981. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_36417/2557711519.py\", line 32, in <module>\n",
       "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "        est,\n",
+      "    ...<3 lines>...\n",
+      "        random_state=0,\n",
+      "    )\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 91, in check_weighted_repeated_estimator_fit_equivalence\n",
       "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
+      "    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n",
+      "        est,\n",
+      "        ^^^^\n",
+      "    ...<6 lines>...\n",
+      "        random_state=random_state,\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 307, in multifit_over_weighted_and_repeated\n",
       "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
-      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 241, in check_pipeline_and_fit\n",
       "    est = est.fit(X, y, sample_weight=sample_weight)\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1363, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1249, in fit\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1248, in fit\n",
       "    return super().fit(X, y, sample_weight=sample_weight)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 990, in fit\n",
       "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
-      "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "                                             ~~~~~~~~~~~~~~~~~^\n",
+      "        X,\n",
+      "        ^^\n",
+      "    ...<13 lines>...\n",
+      "        **params,\n",
+      "        ^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 765, in _ridge_regression\n",
       "    coef_, n_iter_, _ = sag_solver(\n",
-      "                        ^^^^^^^^^^^\n",
+      "                        ~~~~~~~~~~^\n",
+      "        X,\n",
+      "        ^^\n",
+      "    ...<12 lines>...\n",
+      "        is_saga=solver == \"saga\",\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
       "    num_seen, n_iter_ = sag(\n",
-      "                        ^^^^\n",
+      "                        ~~~^\n",
+      "        dataset,\n",
+      "        ^^^^^^^^\n",
+      "    ...<19 lines>...\n",
+      "        verbose,\n",
+      "        ^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
       "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #1006. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #981. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "\n",
-      "❌ RidgeClassifier(max_iter=100000, solver='saga'): Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "❌ RidgeClassifier(max_iter=100000, solver='saga'): Floating-point under-/overflow occurred at epoch #861. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_72266/2504969921.py\", line 49, in <module>\n",
+      "  File \"/var/folders/_y/lfnx34p13w3_sr2k12bjb05w0000gn/T/ipykernel_36417/2557711519.py\", line 32, in <module>\n",
       "    result = check_weighted_repeated_estimator_fit_equivalence(\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 90, in check_weighted_repeated_estimator_fit_equivalence\n",
+      "        est,\n",
+      "    ...<3 lines>...\n",
+      "        random_state=0,\n",
+      "    )\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 91, in check_weighted_repeated_estimator_fit_equivalence\n",
       "    multifit_over_weighted_and_repeated(\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 288, in multifit_over_weighted_and_repeated\n",
+      "    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n",
+      "        est,\n",
+      "        ^^^^\n",
+      "    ...<6 lines>...\n",
+      "        random_state=random_state,\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 307, in multifit_over_weighted_and_repeated\n",
       "    est_ref = check_pipeline_and_fit(est_ref, X_train, y_train, sample_weight_train)\n",
-      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 224, in check_pipeline_and_fit\n",
+      "  File \"/Users/ogrisel/code/sample-weight-audit-nondet/src/sample_weight_audit/estimator_check.py\", line 241, in check_pipeline_and_fit\n",
       "    est = est.fit(X, y, sample_weight=sample_weight)\n",
-      "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1389, in wrapper\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/base.py\", line 1363, in wrapper\n",
       "    return fit_method(estimator, *args, **kwargs)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1571, in fit\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 1570, in fit\n",
       "    super().fit(X, Y, sample_weight=sample_weight)\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 991, in fit\n",
+      "    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 990, in fit\n",
       "    self.coef_, self.n_iter_, self.solver_ = _ridge_regression(\n",
-      "                                             ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 766, in _ridge_regression\n",
+      "                                             ~~~~~~~~~~~~~~~~~^\n",
+      "        X,\n",
+      "        ^^\n",
+      "    ...<13 lines>...\n",
+      "        **params,\n",
+      "        ^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
+      "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_ridge.py\", line 765, in _ridge_regression\n",
       "    coef_, n_iter_, _ = sag_solver(\n",
-      "                        ^^^^^^^^^^^\n",
+      "                        ~~~~~~~~~~^\n",
+      "        X,\n",
+      "        ^^\n",
+      "    ...<12 lines>...\n",
+      "        is_saga=solver == \"saga\",\n",
+      "        ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
       "  File \"/Users/ogrisel/code/scikit-learn/sklearn/linear_model/_sag.py\", line 323, in sag_solver\n",
       "    num_seen, n_iter_ = sag(\n",
-      "                        ^^^^\n",
+      "                        ~~~^\n",
+      "        dataset,\n",
+      "        ^^^^^^^^\n",
+      "    ...<19 lines>...\n",
+      "        verbose,\n",
+      "        ^^^^^^^^\n",
+      "    )\n",
+      "    ^\n",
       "  File \"sklearn/linear_model/_sag_fast.pyx\", line 396, in sklearn.linear_model._sag_fast.sag64\n",
-      "ValueError: Floating-point under-/overflow occurred at epoch #884. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
+      "ValueError: Floating-point under-/overflow occurred at epoch #861. Scaling input data with StandardScaler or MinMaxScaler might help.\n",
       "\n"
      ]
     }
@@ -2288,6 +2754,8 @@
       "SparsePCA\n",
       "SparseRandomProjection\n",
       "SpectralClustering\n",
+      "StackingClassifier\n",
+      "StackingRegressor\n",
       "TSNE\n",
       "TargetEncoder\n",
       "TfidfTransformer\n",
@@ -2295,7 +2763,9 @@
       "TransformedTargetRegressor\n",
       "TruncatedSVD\n",
       "TunedThresholdClassifierCV\n",
-      "VarianceThreshold\n"
+      "VarianceThreshold\n",
+      "VotingClassifier\n",
+      "VotingRegressor\n"
      ]
     }
    ],
@@ -2431,7 +2901,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
While trying to review the `TargetEncoder` PR (https://github.com/scikit-learn/scikit-learn/pull/31324) I found some limitations in our generic handling of estimators:

- the `cv` parameters could be passed inside a pipeline, not just for the final estimator;
- the estimator to test might need some binning of the input features if they only accept categorical inputs.

In the process I found this bug: https://github.com/scikit-learn/scikit-learn/pull/31556.